### PR TITLE
fix: Handle references with name instead of label

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.1.1"
+version = "0.1.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
@@ -65,6 +65,7 @@ public class ReferenceUtil {
 
   @Label
   public String label(Map<String, String> data) {
-    return data.get("label");
+    // Fall back to name if label is not found in the data map, to support types like College.
+    return data.getOrDefault("label", data.get("name"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.ReflectionUtils;
+import uk.nhs.hee.tis.trainee.sync.dto.ReferenceDto;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class ReferenceMapperTest {
+
+  private ReferenceMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ReferenceMapperImpl();
+
+    Field field = ReflectionUtils.findField(ReferenceMapperImpl.class, "referenceUtil");
+    field.setAccessible(true);
+    ReflectionUtils.setField(field, mapper, new ReferenceUtil());
+  }
+
+  @Test
+  void shouldMapLabelToLabelWhenLabelPresent() {
+    Record record = new Record();
+    record.setData(Map.of("label", "labelContent", "name", "nameContent"));
+
+    ReferenceDto reference = mapper.toReference(record);
+
+    assertThat("Unexpected label.", reference.getLabel(), is("labelContent"));
+  }
+
+  @Test
+  void shouldMapNameToLabelWhenLabelNotPresent() {
+    Record record = new Record();
+    record.setData(Collections.singletonMap("name", "nameContent"));
+
+    ReferenceDto reference = mapper.toReference(record);
+
+    assertThat("Unexpected label.", reference.getLabel(), is("nameContent"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
@@ -76,8 +76,6 @@ class ReferenceSyncServiceTest {
     Record record = new Record();
     record.setTable("Grade");
     record.setOperation("unsupportedOperation");
-    record.setData(Collections.emptyMap());
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 
@@ -91,8 +89,6 @@ class ReferenceSyncServiceTest {
     Record record = new Record();
     record.setTable(tableName);
     record.setOperation("load");
-    record.setData(Collections.emptyMap());
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 
@@ -107,8 +103,6 @@ class ReferenceSyncServiceTest {
     Record record = new Record();
     record.setTable(tableName);
     record.setOperation("insert");
-    record.setData(Collections.emptyMap());
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 
@@ -123,8 +117,6 @@ class ReferenceSyncServiceTest {
     Record record = new Record();
     record.setTable(tableName);
     record.setOperation("update");
-    record.setData(Collections.emptyMap());
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 
@@ -140,7 +132,6 @@ class ReferenceSyncServiceTest {
     record.setTable(tableName);
     record.setOperation("delete");
     record.setData(Collections.singletonMap("id", "40"));
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 
@@ -155,7 +146,6 @@ class ReferenceSyncServiceTest {
     record.setTable("Grade");
     record.setOperation(operation);
     record.setData(Map.of("id", "40", "status", "INACTIVE"));
-    record.setMetadata(Collections.emptyMap());
 
     service.syncRecord(record);
 


### PR DESCRIPTION
Some reference types such as College and LocalOffice use a `name` field
instead of `label`. If label is not populated then fall back to the name
field's value.

TISNEW-4307