### PR TITLE
fix: Don't throw exception when trainee not found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.2.0"
+version = "0.2.1"
 sourceCompatibility = "11"
 
 configurations {


### PR DESCRIPTION
A trainee not being found in the trainee details service is a valid
use case, in such scenarios we simply do not process the record.
Currently when a 404 is returned an exception is throw, which breaks the
kinesis stream updates. Catch 404s and simply log the error so that sync
can continue.

TISNEW-5344