### PR TITLE
feat: Synchronize initial skeleton trainee profile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.2.1"
+version = "0.3.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -26,7 +26,7 @@ import lombok.Data;
 @Data
 public class TraineeDetailsDto {
 
-  private String tisId;
+  private String traineeTisId;
 
   // ContactDetails fields.
   private String title;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -48,7 +48,10 @@ import uk.nhs.hee.tis.trainee.sync.model.Record;
     unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TraineeDetailsMapper {
 
-  @Mapping(target = "tisId", source = "data", qualifiedBy = Id.class)
+  @Mapping(target = "traineeTisId", source = "data", qualifiedBy = Id.class)
+  TraineeDetailsDto toTraineeSkeleton(Record record);
+
+  @Mapping(target = "traineeTisId", source = "data", qualifiedBy = Id.class)
   @Mapping(target = "title", source = "data", qualifiedBy = Title.class)
   @Mapping(target = "forenames", source = "data", qualifiedBy = Forenames.class)
   @Mapping(target = "knownAs", source = "data", qualifiedBy = KnownAs.class)
@@ -64,8 +67,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "postCode", source = "data", qualifiedBy = PostCode.class)
   TraineeDetailsDto toContactDetails(Record record);
 
-
-  @Mapping(target = "tisId", source = "data", qualifiedBy = Id.class)
+  @Mapping(target = "traineeTisId", source = "data", qualifiedBy = Id.class)
   @Mapping(target = "dateOfBirth", source = "data", qualifiedBy = DateOfBirth.class)
   @Mapping(target = "gender", source = "data", qualifiedBy = Gender.class)
   TraineeDetailsDto toPersonalInfoDto(Record record);


### PR DESCRIPTION
When the Person table is being updated a skeleton profile should be
created if one does not already exist. This allows other
synchronizations, which depend on a trainee having a TISSS record, to
find the profile to add further details to.

TISNEW-3833