### PR TITLE
Persist placement and post records with flat structure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.7.0"
+version = "0.8.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+@Configuration
+public class MongoConfiguration {
+
+  private final RecordWriteConverter recordWriteConverter;
+  private final RecordReadGenericConverter recordReadGenericConverter;
+
+  MongoConfiguration(RecordWriteConverter recordWriteConverter,
+      RecordReadGenericConverter recordReadGenericConverter) {
+    this.recordWriteConverter = recordWriteConverter;
+    this.recordReadGenericConverter = recordReadGenericConverter;
+  }
+
+  @Bean
+  public MongoCustomConversions mongoCustomConversions() {
+    return new MongoCustomConversions(
+        Arrays.asList(recordWriteConverter, recordReadGenericConverter));
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverter.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.bson.Document;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+@Component
+public class RecordReadGenericConverter implements GenericConverter {
+
+  private final ApplicationContext context;
+
+  RecordReadGenericConverter(ApplicationContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Set<ConvertiblePair> getConvertibleTypes() {
+    return Collections.singleton(new ConvertiblePair(Document.class, Record.class));
+  }
+
+  @Override
+  public Object convert(Object sourceObject, TypeDescriptor sourceType, TypeDescriptor targetType) {
+    Record target = (Record) context.getBean(targetType.getType());
+    Document source = (Document) sourceObject;
+
+    target.setTisId(source.getString("_id"));
+
+    Map<String, String> data = source.keySet().stream()
+        .filter(key -> !key.startsWith("_"))
+        .collect(Collectors.toMap(Function.identity(), source::getString));
+    target.setData(data);
+
+    return target;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverter.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+@Component
+public class RecordWriteConverter implements Converter<Record, Document> {
+
+  @Override
+  public Document convert(Record source) {
+    Document target = new Document();
+    target.put("_id", source.getTisId());
+    source.getData().forEach(target::put);
+    target.put("_class", source.getClass().getName());
+    return target;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
@@ -21,9 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component("Placement")
+@Scope("prototype")
 public class Placement extends Record {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
@@ -21,9 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component("Post")
+@Scope("prototype")
 public class Post extends Record {
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
@@ -1,0 +1,29 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.model;
+
+import org.springframework.stereotype.Component;
+
+@Component("Post")
+public class Post extends Record {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
@@ -26,10 +26,8 @@ import java.util.Map;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
-import org.springframework.stereotype.Component;
 
 @Data
-@Component
 public class Record {
 
   @Id

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PostRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PostRepository.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.sync.model.Post;
+
+@Repository
+public interface PostRepository extends MongoRepository<Post, String> {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import uk.nhs.hee.tis.trainee.sync.mapper.TraineeDetailsMapper;
+import uk.nhs.hee.tis.trainee.sync.repository.PlacementRepository;
+
+@Service("tcs-Placement")
+public class PlacementSyncService extends TcsSyncService {
+
+  PlacementSyncService(RestTemplate restTemplate, TraineeDetailsMapper mapper,
+      PlacementRepository placementRepository) {
+    super(restTemplate, mapper, placementRepository);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
@@ -21,16 +21,33 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import uk.nhs.hee.tis.trainee.sync.mapper.TraineeDetailsMapper;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.repository.PlacementRepository;
 
+@Slf4j
 @Service("tcs-Placement")
-public class PlacementSyncService extends TcsSyncService {
+public class PlacementSyncService implements SyncService {
 
-  PlacementSyncService(RestTemplate restTemplate, TraineeDetailsMapper mapper,
-      PlacementRepository placementRepository) {
-    super(restTemplate, mapper, placementRepository);
+  private final PlacementRepository repository;
+
+  PlacementSyncService(PlacementRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public void syncRecord(Record record) {
+    if (!(record instanceof Placement)) {
+      String message = String.format("Invalid record type '%s'.", record.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    if (record.getOperation().equals("delete")) {
+      repository.deleteById(record.getTisId());
+    } else {
+      repository.save((Placement) record);
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.model.Post;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.PostRepository;
+
+@Service("tcs-Post")
+public class PostSyncService implements SyncService {
+
+  private final PostRepository repository;
+
+  PostSyncService(PostRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public void syncRecord(Record record) {
+    if (!(record instanceof Post)) {
+      String message = String.format("Invalid record type '%s'.", record.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    if (record.getOperation().equals("delete")) {
+      repository.deleteById(record.getTisId());
+    } else {
+      repository.save((Post) record);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -32,9 +32,7 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.sync.dto.TraineeDetailsDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.TraineeDetailsMapper;
-import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
-import uk.nhs.hee.tis.trainee.sync.repository.PlacementRepository;
 
 /**
  * A service for synchronizing reference records.
@@ -71,17 +69,13 @@ public class TcsSyncService implements SyncService {
 
   private final RestTemplate restTemplate;
 
-  private final PlacementRepository placementRepository;
-
   private final Map<String, Function<Record, TraineeDetailsDto>> tableNameToMappingFunction;
 
   @Value("${service.trainee.url}")
   private String serviceUrl;
 
-  TcsSyncService(RestTemplate restTemplate, TraineeDetailsMapper mapper,
-      PlacementRepository placementRepository) {
+  TcsSyncService(RestTemplate restTemplate, TraineeDetailsMapper mapper) {
     this.restTemplate = restTemplate;
-    this.placementRepository = placementRepository;
 
     tableNameToMappingFunction = Map.of(
         TABLE_CONTACT_DETAILS, mapper::toContactDetails,
@@ -114,15 +108,6 @@ public class TcsSyncService implements SyncService {
       return;
     }
 
-    // TODO: Move to a more suitable place, will need to support multiple different record types.
-    if (record instanceof Placement) {
-      if (record.getOperation().equals("delete")) {
-        placementRepository.deleteById(record.getTisId());
-      } else {
-        placementRepository.save((Placement) record);
-      }
-    }
-
     String operationType = record.getOperation();
     syncDetails(dto, apiPath.get(), operationType);
   }
@@ -135,7 +120,6 @@ public class TcsSyncService implements SyncService {
    * @param operationType The operation type of the record being synchronized.
    */
   private void syncDetails(TraineeDetailsDto dto, String apiPath, String operationType) {
-    // TODO: Handle delete of placement from tis-trainee-details.
     switch (operationType) {
       case "insert":
       case "load":

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class MongoConfigurationTest {
+
+  private MongoConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    RecordWriteConverter writeConverter = new RecordWriteConverter();
+    RecordReadGenericConverter readConverter = new RecordReadGenericConverter(null);
+    configuration = new MongoConfiguration(writeConverter, readConverter);
+  }
+
+  @Test
+  void shouldRegisterDocumentToRecordReadConverter() {
+    MongoCustomConversions mongoCustomConversions = configuration.mongoCustomConversions();
+
+    boolean registered = mongoCustomConversions.hasCustomReadTarget(Document.class, Record.class);
+    assertThat("Custom conversion not registered.", registered, is(true));
+  }
+
+  @Test
+  void shouldRegisterRecordToDocumentWriteConverter() {
+    MongoCustomConversions mongoCustomConversions = configuration.mongoCustomConversions();
+
+    boolean registered = mongoCustomConversions.hasCustomWriteTarget(Record.class, Document.class);
+    assertThat("Custom conversion not registered.", registered, is(true));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class RecordReadGenericConverterTest {
+
+  private RecordReadGenericConverter converter;
+
+  private ApplicationContext context;
+
+  @BeforeEach
+  void setUp() {
+    context = mock(ApplicationContext.class);
+    converter = new RecordReadGenericConverter(context);
+  }
+
+  @Test
+  void shouldReturnSingleDocumentToRecordConvertableTypes() {
+    Set<ConvertiblePair> convertibleTypes = converter.getConvertibleTypes();
+
+    assertThat("Unexpected number of convertible types.", convertibleTypes.size(), is(1));
+
+    ConvertiblePair convertiblePair = convertibleTypes.iterator().next();
+    assertThat("Unexpected source type.", convertiblePair.getSourceType(), is(Document.class));
+    assertThat("Unexpected target type.", convertiblePair.getTargetType(), is(Record.class));
+  }
+
+  @Test
+  void shouldConvertToTheGivenSubType() {
+    Document source = new Document();
+    source.put("_id", "idValue");
+    source.put("data1", "data1Value");
+    source.put("data2", "data2Value");
+    source.put("data3", "data3Value");
+    source.put("data4", "data4Value");
+
+    TypeDescriptor sourceType = TypeDescriptor.forObject(source);
+    TypeDescriptor targetType = TypeDescriptor.valueOf(Placement.class);
+
+    when(context.getBean(Placement.class)).thenReturn(new Placement());
+
+    Object targetObject = converter.convert(source, sourceType, targetType);
+    assertThat("Unexpected converted type.", targetObject, instanceOf(Placement.class));
+
+    Placement target = (Placement) targetObject;
+    assertThat("Unexpected tisID value.", target.getTisId(), is("idValue"));
+
+    Map<String, String> data = target.getData();
+    assertThat("Unexpected data size.", data.size(), is(4));
+    assertThat("Unexpected data value.", data.get("data1"), is("data1Value"));
+    assertThat("Unexpected data value.", data.get("data2"), is("data2Value"));
+    assertThat("Unexpected data value.", data.get("data3"), is("data3Value"));
+    assertThat("Unexpected data value.", data.get("data4"), is("data4Value"));
+
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+
+class RecordWriteConverterTest {
+
+  private RecordWriteConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new RecordWriteConverter();
+  }
+
+  @Test
+  void shouldConvertToDocument() {
+    Placement record = new Placement();
+    record.setTisId("idValue");
+
+    Map<String, String> data = new HashMap<>();
+    data.put("data1", "data1Value");
+    data.put("data2", "data2Value");
+    data.put("data3", "data3Value");
+    data.put("data4", "data4Value");
+    record.setData(data);
+
+    Document document = converter.convert(record);
+
+    assertThat("Unexpected identifier.", document.getString("_id"), is("idValue"));
+    assertThat("Unexpected class.", document.getString("_class"), is(Placement.class.getName()));
+    assertThat("Unexpected data value.", document.getString("data1"), is("data1Value"));
+    assertThat("Unexpected data value.", document.getString("data2"), is("data2Value"));
+    assertThat("Unexpected data value.", document.getString("data3"), is("data3Value"));
+    assertThat("Unexpected data value.", document.getString("data4"), is("data4Value"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
@@ -50,7 +50,8 @@ class PlacementSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotPlacement() {
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(new Record()));
+    Record record = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
   @ParameterizedTest(

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.LocalDate;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.PlacementRepository;
+
+class PlacementSyncServiceTest {
+
+  private PlacementSyncService service;
+
+  private PlacementRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(PlacementRepository.class);
+    service = new PlacementSyncService(repository);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotPlacement() {
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(new Record()));
+  }
+
+  @ParameterizedTest(
+      name = "Should store placements when operation is {0} and table is Placement")
+  @ValueSource(strings = {"load", "insert", "update"})
+  void shouldStorePlacements(String operation) {
+    LocalDate now = LocalDate.now();
+
+    Map<String, String> data = Map.of(
+        "traineeId", "traineeIdValue",
+        "dateFrom", now.toString(),
+        "dateTo", now.plusYears(1).toString(),
+        "gradeAbbreviation", "gradeValue",
+        "placementType", "placementTypeValue",
+        "status", "statusValue");
+
+    Placement record = new Placement();
+    record.setTisId("idValue");
+    record.setTable("Placement");
+    record.setOperation(operation);
+    record.setData(data);
+
+    service.syncRecord(record);
+
+    verify(repository).save(record);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeletePlacementFromStore() {
+    LocalDate now = LocalDate.now();
+
+    Map<String, String> data = Map.of(
+        "traineeId", "traineeIdValue",
+        "dateFrom", now.toString(),
+        "dateTo", now.plusYears(1).toString(),
+        "gradeAbbreviation", "gradeValue",
+        "placementType", "placementTypeValue",
+        "status", "statusValue");
+
+    Placement record = new Placement();
+    record.setTisId("idValue");
+    record.setTable("Placement");
+    record.setOperation("delete");
+    record.setData(data);
+
+    service.syncRecord(record);
+
+    verify(repository).deleteById("idValue");
+    verifyNoMoreInteractions(repository);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -48,7 +48,8 @@ class PostSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotPost() {
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(new Record()));
+    Record record = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
   @ParameterizedTest(

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.hee.tis.trainee.sync.model.Post;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.PostRepository;
+
+class PostSyncServiceTest {
+
+  private PostSyncService service;
+
+  private PostRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(PostRepository.class);
+    service = new PostSyncService(repository);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotPost() {
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(new Record()));
+  }
+
+  @ParameterizedTest(
+      name = "Should store posts when operation is {0} and table is Post")
+  @ValueSource(strings = {"load", "insert", "update"})
+  void shouldStorePosts(String operation) {
+    Post record = new Post();
+    record.setTisId("idValue");
+    record.setTable("Post");
+    record.setOperation(operation);
+
+    service.syncRecord(record);
+
+    verify(repository).save(record);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeletePostFromStore() {
+    Post record = new Post();
+    record.setTisId("idValue");
+    record.setTable("Post");
+    record.setOperation("delete");
+
+    service.syncRecord(record);
+
+    verify(repository).deleteById("idValue");
+    verifyNoMoreInteractions(repository);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -49,9 +49,7 @@ import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.sync.dto.TraineeDetailsDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.TraineeDetailsMapperImpl;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil;
-import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
-import uk.nhs.hee.tis.trainee.sync.repository.PlacementRepository;
 
 class TcsSyncServiceTest {
 
@@ -65,8 +63,6 @@ class TcsSyncServiceTest {
 
   private Record record;
 
-  private PlacementRepository placementRepository;
-
   @BeforeEach
   void setUp() {
     TraineeDetailsMapperImpl mapper = new TraineeDetailsMapperImpl();
@@ -76,8 +72,7 @@ class TcsSyncServiceTest {
     ReflectionUtils.setField(field, mapper, new TraineeDetailsUtil());
 
     restTemplate = mock(RestTemplate.class);
-    placementRepository = mock(PlacementRepository.class);
-    service = new TcsSyncService(restTemplate, mapper, placementRepository);
+    service = new TcsSyncService(restTemplate, mapper);
 
     data = new HashMap<>();
     data.put("id", "idValue");
@@ -337,95 +332,6 @@ class TcsSyncServiceTest {
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("qualification"),
             eq("personIdValue"));
     verifyNoMoreInteractions(restTemplate);
-  }
-
-  @ParameterizedTest(
-      name = "Should patch placements when operation is {0} and table is Placement")
-  @ValueSource(strings = {"load", "insert", "update"})
-  void shouldPatchPlacements(String operation) {
-    LocalDate now = LocalDate.now();
-
-    Map<String, String> data = Map.of(
-        "traineeId", "traineeIdValue",
-        "dateFrom", now.toString(),
-        "dateTo", now.plusYears(1).toString(),
-        "gradeAbbreviation", "gradeValue",
-        "placementType", "placementTypeValue",
-        "status", "statusValue");
-
-    Placement record = new Placement();
-    record.setTisId("idValue");
-    record.setTable("Placement");
-    record.setOperation(operation);
-    record.setData(data);
-
-    service.syncRecord(record);
-
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTisId("idValue");
-    expectedDto.setTraineeTisId("traineeIdValue");
-    expectedDto.setStartDate(now);
-    expectedDto.setEndDate(now.plusYears(1));
-    expectedDto.setGrade("gradeValue");
-    expectedDto.setPlacementType("placementTypeValue");
-    expectedDto.setStatus("statusValue");
-
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("placement"),
-            eq("traineeIdValue"));
-    verifyNoMoreInteractions(restTemplate);
-  }
-
-  @ParameterizedTest(
-      name = "Should store placements when operation is {0} and table is Placement")
-  @ValueSource(strings = {"load", "insert", "update"})
-  void shouldStorePlacements(String operation) {
-    LocalDate now = LocalDate.now();
-
-    Map<String, String> data = Map.of(
-        "traineeId", "traineeIdValue",
-        "dateFrom", now.toString(),
-        "dateTo", now.plusYears(1).toString(),
-        "gradeAbbreviation", "gradeValue",
-        "placementType", "placementTypeValue",
-        "status", "statusValue");
-
-    Placement record = new Placement();
-    record.setTisId("idValue");
-    record.setTable("Placement");
-    record.setOperation(operation);
-    record.setData(data);
-
-    service.syncRecord(record);
-
-    verify(placementRepository).save(record);
-    verifyNoMoreInteractions(placementRepository);
-  }
-
-  @ParameterizedTest(
-      name = "Should delete placement when operation is delete and table is Placement")
-  @ValueSource(strings = {"load", "insert", "update"})
-  void shouldDeletePlacementFromStore() {
-    LocalDate now = LocalDate.now();
-
-    Map<String, String> data = Map.of(
-        "traineeId", "traineeIdValue",
-        "dateFrom", now.toString(),
-        "dateTo", now.plusYears(1).toString(),
-        "gradeAbbreviation", "gradeValue",
-        "placementType", "placementTypeValue",
-        "status", "statusValue");
-
-    Placement record = new Placement();
-    record.setTisId("idValue");
-    record.setTable("Placement");
-    record.setOperation("delete");
-    record.setData(data);
-
-    service.syncRecord(record);
-
-    verify(placementRepository).deleteById("idValue");
-    verifyNoMoreInteractions(placementRepository);
   }
 
   @ParameterizedTest(name = "Should do nothing when operation is DELETE and table is {0}")


### PR DESCRIPTION
Placement and Posts should be persisted when received.
Use custom converters to allow the object data to be stored in a flat structure within mongo, rather than as a "data" sub-document of the placement/post.