### PR TITLE
feat: Flatten persisted records

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import java.util.Arrays;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+@Configuration
+public class MongoConfiguration {
+
+  private final RecordWriteConverter recordWriteConverter;
+  private final RecordReadGenericConverter recordReadGenericConverter;
+
+  MongoConfiguration(RecordWriteConverter recordWriteConverter,
+      RecordReadGenericConverter recordReadGenericConverter) {
+    this.recordWriteConverter = recordWriteConverter;
+    this.recordReadGenericConverter = recordReadGenericConverter;
+  }
+
+  @Bean
+  public MongoCustomConversions mongoCustomConversions() {
+    return new MongoCustomConversions(
+        Arrays.asList(recordWriteConverter, recordReadGenericConverter));
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverter.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.bson.Document;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+@Component
+public class RecordReadGenericConverter implements GenericConverter {
+
+  private final ApplicationContext context;
+
+  RecordReadGenericConverter(ApplicationContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public Set<ConvertiblePair> getConvertibleTypes() {
+    return Collections.singleton(new ConvertiblePair(Document.class, Record.class));
+  }
+
+  @Override
+  public Object convert(Object sourceObject, TypeDescriptor sourceType, TypeDescriptor targetType) {
+    Record target = (Record) context.getBean(targetType.getType());
+    Document source = (Document) sourceObject;
+
+    target.setTisId(source.getString("_id"));
+
+    Map<String, String> data = source.keySet().stream()
+        .filter(key -> !key.startsWith("_"))
+        .collect(Collectors.toMap(Function.identity(), source::getString));
+    target.setData(data);
+
+    return target;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverter.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverter.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import org.bson.Document;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+@Component
+public class RecordWriteConverter implements Converter<Record, Document> {
+
+  @Override
+  public Document convert(Record source) {
+    Document target = new Document();
+    target.put("_id", source.getTisId());
+    source.getData().forEach(target::put);
+    target.put("_class", source.getClass().getName());
+    return target;
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/MongoConfigurationTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class MongoConfigurationTest {
+
+  private MongoConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    RecordWriteConverter writeConverter = new RecordWriteConverter();
+    RecordReadGenericConverter readConverter = new RecordReadGenericConverter(null);
+    configuration = new MongoConfiguration(writeConverter, readConverter);
+  }
+
+  @Test
+  void shouldRegisterDocumentToRecordReadConverter() {
+    MongoCustomConversions mongoCustomConversions = configuration.mongoCustomConversions();
+
+    boolean registered = mongoCustomConversions.hasCustomReadTarget(Document.class, Record.class);
+    assertThat("Custom conversion not registered.", registered, is(true));
+  }
+
+  @Test
+  void shouldRegisterRecordToDocumentWriteConverter() {
+    MongoCustomConversions mongoCustomConversions = configuration.mongoCustomConversions();
+
+    boolean registered = mongoCustomConversions.hasCustomWriteTarget(Record.class, Document.class);
+    assertThat("Custom conversion not registered.", registered, is(true));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordReadGenericConverterTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.GenericConverter.ConvertiblePair;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class RecordReadGenericConverterTest {
+
+  private RecordReadGenericConverter converter;
+
+  private ApplicationContext context;
+
+  @BeforeEach
+  void setUp() {
+    context = mock(ApplicationContext.class);
+    converter = new RecordReadGenericConverter(context);
+  }
+
+  @Test
+  void shouldReturnSingleDocumentToRecordConvertableTypes() {
+    Set<ConvertiblePair> convertibleTypes = converter.getConvertibleTypes();
+
+    assertThat("Unexpected number of convertible types.", convertibleTypes.size(), is(1));
+
+    ConvertiblePair convertiblePair = convertibleTypes.iterator().next();
+    assertThat("Unexpected source type.", convertiblePair.getSourceType(), is(Document.class));
+    assertThat("Unexpected target type.", convertiblePair.getTargetType(), is(Record.class));
+  }
+
+  @Test
+  void shouldConvertToTheGivenSubType() {
+    Document source = new Document();
+    source.put("_id", "idValue");
+    source.put("data1", "data1Value");
+    source.put("data2", "data2Value");
+    source.put("data3", "data3Value");
+    source.put("data4", "data4Value");
+
+    TypeDescriptor sourceType = TypeDescriptor.forObject(source);
+    TypeDescriptor targetType = TypeDescriptor.valueOf(Placement.class);
+
+    when(context.getBean(Placement.class)).thenReturn(new Placement());
+
+    Object targetObject = converter.convert(source, sourceType, targetType);
+    assertThat("Unexpected converted type.", targetObject, instanceOf(Placement.class));
+
+    Placement target = (Placement) targetObject;
+    assertThat("Unexpected tisID value.", target.getTisId(), is("idValue"));
+
+    Map<String, String> data = target.getData();
+    assertThat("Unexpected data size.", data.size(), is(4));
+    assertThat("Unexpected data value.", data.get("data1"), is("data1Value"));
+    assertThat("Unexpected data value.", data.get("data2"), is("data2Value"));
+    assertThat("Unexpected data value.", data.get("data3"), is("data3Value"));
+    assertThat("Unexpected data value.", data.get("data4"), is("data4Value"));
+
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverterTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/mongo/RecordWriteConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.config.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+
+class RecordWriteConverterTest {
+
+  private RecordWriteConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new RecordWriteConverter();
+  }
+
+  @Test
+  void shouldConvertToDocument() {
+    Placement record = new Placement();
+    record.setTisId("idValue");
+
+    Map<String, String> data = new HashMap<>();
+    data.put("data1", "data1Value");
+    data.put("data2", "data2Value");
+    data.put("data3", "data3Value");
+    data.put("data4", "data4Value");
+    record.setData(data);
+
+    Document document = converter.convert(record);
+
+    assertThat("Unexpected identifier.", document.getString("_id"), is("idValue"));
+    assertThat("Unexpected class.", document.getString("_class"), is(Placement.class.getName()));
+    assertThat("Unexpected data value.", document.getString("data1"), is("data1Value"));
+    assertThat("Unexpected data value.", document.getString("data2"), is("data2Value"));
+    assertThat("Unexpected data value.", document.getString("data3"), is("data3Value"));
+    assertThat("Unexpected data value.", document.getString("data4"), is("data4Value"));
+  }
+}


### PR DESCRIPTION
When the record is stored as a mongo document it is stored with the
`data` map as an object within the document.
Create read and write converters to allow the data map to be flattened
for storage and read back in to a map during retrieval.

TIS21-1032