### PR TITLE
Feature/add services for Placement <-> Post <-> Trust

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.8.0"
+version = "0.9.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.model;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component("Trust")
+@Scope("prototype")
+public class Trust extends Record {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementRepository.java
@@ -21,11 +21,15 @@
 
 package uk.nhs.hee.tis.trainee.sync.repository;
 
+import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 
 @Repository
 public interface PlacementRepository extends MongoRepository<Placement, String> {
 
+  @Query("{ 'data.postId' : ?0}")
+  Set<Placement> findByPostId(String postId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PostRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PostRepository.java
@@ -21,11 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.repository;
 
+import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 
 @Repository
 public interface PostRepository extends MongoRepository<Post, String> {
 
+  @Query("{ 'data.employingBody' : ?0}")
+  Set<Post> findByEmployingBodyId(String trustId);
+
+  @Query("{ 'data.trainingBody' : ?0}")
+  Set<Post> findByTrainingBodyId(String trustId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/TrustRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/TrustRepository.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.sync.model.Trust;
+
+@Repository
+public interface TrustRepository extends MongoRepository<Trust, String> {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
@@ -49,5 +50,14 @@ public class PlacementSyncService implements SyncService {
     } else {
       repository.save((Placement) record);
     }
+  }
+
+  public Set<Placement> findByPostId(String postId) {
+    return repository.findByPostId(postId);
+  }
+
+  public void request(String id) {
+    // TODO: Implement.
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
@@ -47,5 +49,22 @@ public class PostSyncService implements SyncService {
     } else {
       repository.save((Post) record);
     }
+  }
+
+  public Optional<Post> findById(String id) {
+    return repository.findById(id);
+  }
+
+  public Set<Post> findByEmployingBodyId(String trustId) {
+    return repository.findByEmployingBodyId(trustId);
+  }
+
+  public Set<Post> findByTrainingBodyId(String trustId) {
+    return repository.findByTrainingBodyId(trustId);
+  }
+
+  public void request(String id) {
+    // TODO: Implement.
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.model.Trust;
@@ -47,5 +48,14 @@ public class TrustSyncService implements SyncService {
     } else {
       repository.save((Trust) record);
     }
+  }
+
+  public Optional<Trust> findById(String id) {
+    return repository.findById(id);
+  }
+
+  public void request(String id) {
+    // TODO: Implement.
+    throw new UnsupportedOperationException();
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.model.Trust;
+import uk.nhs.hee.tis.trainee.sync.repository.TrustRepository;
+
+@Service("reference-Trust")
+public class TrustSyncService implements SyncService {
+
+  private final TrustRepository repository;
+
+  TrustSyncService(TrustRepository repository) {
+    this.repository = repository;
+  }
+
+  @Override
+  public void syncRecord(Record record) {
+    if (!(record instanceof Trust)) {
+      String message = String.format("Invalid record type '%s'.", record.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    if (record.getOperation().equals("delete")) {
+      repository.deleteById(record.getTisId());
+    } else {
+      repository.save((Trust) record);
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
@@ -54,8 +54,7 @@ class PlacementSyncServiceTest {
     assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
-  @ParameterizedTest(
-      name = "Should store placements when operation is {0} and table is Placement")
+  @ParameterizedTest(name = "Should store placements when operation is {0}.")
   @ValueSource(strings = {"load", "insert", "update"})
   void shouldStorePlacements(String operation) {
     LocalDate now = LocalDate.now();
@@ -70,7 +69,6 @@ class PlacementSyncServiceTest {
 
     Placement record = new Placement();
     record.setTisId("idValue");
-    record.setTable("Placement");
     record.setOperation(operation);
     record.setData(data);
 
@@ -94,7 +92,6 @@ class PlacementSyncServiceTest {
 
     Placement record = new Placement();
     record.setTisId("idValue");
-    record.setTable("Placement");
     record.setOperation("delete");
     record.setData(data);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -21,11 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,14 +43,21 @@ import uk.nhs.hee.tis.trainee.sync.repository.PostRepository;
 
 class PostSyncServiceTest {
 
+  private static final String ID = "40";
+
   private PostSyncService service;
 
   private PostRepository repository;
+
+  private Post record;
 
   @BeforeEach
   void setUp() {
     repository = mock(PostRepository.class);
     service = new PostSyncService(repository);
+
+    record = new Post();
+    record.setTisId(ID);
   }
 
   @Test
@@ -52,11 +66,9 @@ class PostSyncServiceTest {
     assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
-  @ParameterizedTest(name = "Should store posts when operation is {0}.")
+  @ParameterizedTest(name = "Should store records when operation is {0}.")
   @ValueSource(strings = {"load", "insert", "update"})
-  void shouldStorePosts(String operation) {
-    Post record = new Post();
-    record.setTisId("idValue");
+  void shouldStoreRecords(String operation) {
     record.setOperation(operation);
 
     service.syncRecord(record);
@@ -66,14 +78,90 @@ class PostSyncServiceTest {
   }
 
   @Test
-  void shouldDeletePostFromStore() {
-    Post record = new Post();
-    record.setTisId("idValue");
+  void shouldDeleteRecordFromStore() {
     record.setOperation("delete");
 
     service.syncRecord(record);
 
-    verify(repository).deleteById("idValue");
+    verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByIdWhenExists() {
+    when(repository.findById(ID)).thenReturn(Optional.of(record));
+
+    Optional<Post> found = service.findById(ID);
+    assertThat("Record not found.", found.isPresent(), is(true));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdWhenNotExists() {
+    when(repository.findById(ID)).thenReturn(Optional.empty());
+
+    Optional<Post> found = service.findById(ID);
+    assertThat("Record not found.", found.isEmpty(), is(true));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByEmployingBodyIdWhenExists() {
+    when(repository.findByEmployingBodyId(ID)).thenReturn(Collections.singleton(record));
+
+    Set<Post> foundRecords = service.findByEmployingBodyId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    Post foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+
+    verify(repository).findByEmployingBodyId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdEmployingBodyWhenNotExists() {
+    when(repository.findByEmployingBodyId(ID)).thenReturn(Collections.emptySet());
+
+    Set<Post> foundRecords = service.findByEmployingBodyId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findByEmployingBodyId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByTrainingBodyIdWhenExists() {
+    when(repository.findByTrainingBodyId(ID)).thenReturn(Collections.singleton(record));
+
+    Set<Post> foundRecords = service.findByTrainingBodyId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    Post foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+
+    verify(repository).findByTrainingBodyId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdTrainingBodyWhenNotExists() {
+    when(repository.findByTrainingBodyId(ID)).thenReturn(Collections.emptySet());
+
+    Set<Post> foundRecords = service.findByTrainingBodyId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findByTrainingBodyId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldSendRetrievalRequest() {
+    assertThrows(UnsupportedOperationException.class, () -> service.request(ID));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -52,13 +52,11 @@ class PostSyncServiceTest {
     assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
-  @ParameterizedTest(
-      name = "Should store posts when operation is {0} and table is Post")
+  @ParameterizedTest(name = "Should store posts when operation is {0}.")
   @ValueSource(strings = {"load", "insert", "update"})
   void shouldStorePosts(String operation) {
     Post record = new Post();
     record.setTisId("idValue");
-    record.setTable("Post");
     record.setOperation(operation);
 
     service.syncRecord(record);
@@ -71,7 +69,6 @@ class PostSyncServiceTest {
   void shouldDeletePostFromStore() {
     Post record = new Post();
     record.setTisId("idValue");
-    record.setTable("Post");
     record.setOperation("delete");
 
     service.syncRecord(record);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
@@ -52,8 +52,7 @@ class TrustSyncServiceTest {
     assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
   }
 
-  @ParameterizedTest(
-      name = "Should store trusts when operation is {0}.")
+  @ParameterizedTest(name = "Should store trusts when operation is {0}.")
   @ValueSource(strings = {"load", "insert", "update"})
   void shouldStoreTrusts(String operation) {
     Trust record = new Trust();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.model.Trust;
+import uk.nhs.hee.tis.trainee.sync.repository.TrustRepository;
+
+class TrustSyncServiceTest {
+
+  private TrustSyncService service;
+
+  private TrustRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(TrustRepository.class);
+    service = new TrustSyncService(repository);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotPost() {
+    Record record = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+  }
+
+  @ParameterizedTest(
+      name = "Should store trusts when operation is {0}.")
+  @ValueSource(strings = {"load", "insert", "update"})
+  void shouldStoreTrusts(String operation) {
+    Trust record = new Trust();
+    record.setTisId("idValue");
+    record.setOperation(operation);
+
+    service.syncRecord(record);
+
+    verify(repository).save(record);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeleteTrustFromStore() {
+    Trust record = new Trust();
+    record.setTisId("idValue");
+    record.setOperation("delete");
+
+    service.syncRecord(record);
+
+    verify(repository).deleteById("idValue");
+    verifyNoMoreInteractions(repository);
+  }
+}


### PR DESCRIPTION
To fully populate the placement record it must be possible to get all of the associated Placement, Post and Trust from either of the record types.
Add service and repository methods to facilitate those lookups.