### PR TITLE
chore: Provide runtime credentials in pre-prod

### DIFF
--- a/.aws/task-definition-pre-prod.json
+++ b/.aws/task-definition-pre-prod.json
@@ -71,6 +71,7 @@
     }
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
+  "taskRoleArn": "tis-trainee-sync_task-role_pre-prod",
   "family": "tis-trainee-sync",
   "requiresCompatibilities": [
     "FARGATE"


### PR DESCRIPTION
A connection to SQS requires AWS credentials to be provided, add the
missing task role so these can be provided automatically during deploy.

TIS21-1032