### PR TITLE
fix: Do not send duplicate request for data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.10.4"
+version = "0.10.5"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -125,10 +127,47 @@ class PlacementSyncServiceTest {
   }
 
   @Test
-  void shouldSendARequestForPlacement() throws JsonProcessingException {
+  void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
+    service.request(ID);
+    verify(dataRequestService).sendRequest("Placement", ID);
+  }
+
+  @Test
+  void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
+    service.request(ID);
+    service.request(ID);
+    verify(dataRequestService, atMostOnce()).sendRequest("Placement", ID);
+    verifyNoMoreInteractions(dataRequestService);
+  }
+
+  @Test
+  void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    verify(dataRequestService).sendRequest("Placement", ID);
+    record.setOperation(DELETE);
+    service.syncRecord(record);
+
+    service.request(ID);
+    verify(dataRequestService, times(2)).sendRequest("Placement", ID);
+  }
+
+  @Test
+  void shouldSendRequestWhenRequestedDifferentIds() throws JsonProcessingException {
+    service.request(ID);
+    service.request("140");
+    verify(dataRequestService, atMostOnce()).sendRequest("Placement", ID);
+    verify(dataRequestService, atMostOnce()).sendRequest("Placement", "140");
+  }
+
+  @Test
+  void shouldSendRequestWhenFirstRequestFails() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyString());
+
+    service.request(ID);
+    service.request(ID);
+
+    verify(dataRequestService, times(2)).sendRequest("Placement", ID);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -28,8 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -171,9 +173,47 @@ class PostSyncServiceTest {
   }
 
   @Test
-  void shouldSendRetrievalRequest() throws JsonProcessingException {
+  void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
     service.request(ID);
     verify(dataRequestService).sendRequest("Post", ID);
+  }
+
+  @Test
+  void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
+    service.request(ID);
+    service.request(ID);
+    verify(dataRequestService, atMostOnce()).sendRequest("Post", ID);
+    verifyNoMoreInteractions(dataRequestService);
+  }
+
+  @Test
+  void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
+    service.request(ID);
+
+    record.setOperation(DELETE);
+    service.syncRecord(record);
+
+    service.request(ID);
+    verify(dataRequestService, times(2)).sendRequest("Post", ID);
+  }
+
+  @Test
+  void shouldSendRequestWhenRequestedDifferentIds() throws JsonProcessingException {
+    service.request(ID);
+    service.request("140");
+    verify(dataRequestService, atMostOnce()).sendRequest("Post", ID);
+    verify(dataRequestService, atMostOnce()).sendRequest("Post", "140");
+  }
+
+  @Test
+  void shouldSendRequestWhenFirstRequestFails() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyString());
+
+    service.request(ID);
+    service.request(ID);
+
+    verify(dataRequestService, times(2)).sendRequest("Post", ID);
   }
 
   @Test


### PR DESCRIPTION
Requests are sent for every object not found, regardless of whether it
has already been requested. Keep track of the IDs that have been
requested and skip the request if it is already pending.
When a record is received for syncing remove it from the requested ID
list if found.

TIS21-1032