### PR TITLE
chore: Refactor syncService entity name references

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
@@ -83,7 +83,7 @@ public class PlacementSyncService implements SyncService {
       log.info("Sending request for Placement [{}]", id);
 
       try {
-        dataRequestService.sendRequest("Placement", id);
+        dataRequestService.sendRequest(Placement.ENTITY_NAME, id);
         requestedIds.add(id);
       } catch (JsonProcessingException e) {
         log.error("Error while trying to retrieve a Placement", e);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncService.java
@@ -74,7 +74,7 @@ public class SiteSyncService implements SyncService {
       log.info("Sending request for Site [{}]", id);
 
       try {
-        dataRequestService.sendRequest("Site", id);
+        dataRequestService.sendRequest(Site.ENTITY_NAME, id);
         requestedIds.add(id);
       } catch (JsonProcessingException e) {
         log.error("Error while trying to request a Site", e);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
@@ -80,7 +80,7 @@ public class TrustSyncService implements SyncService {
       log.info("Sending request for Trust [{}]", id);
 
       try {
-        dataRequestService.sendRequest("Trust", id);
+        dataRequestService.sendRequest(Trust.ENTITY_NAME, id);
         requestedIds.add(id);
       } catch (JsonProcessingException e) {
         log.error("Error while trying to retrieve a Trust", e);


### PR DESCRIPTION
To make consistent with PostSyncService and other usage