### PR TITLE
chore: Set queue URL in task definitions per env

### DIFF
--- a/.aws/task-definition-pre-prod.json
+++ b/.aws/task-definition-pre-prod.json
@@ -66,6 +66,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-sync-sentry-dsn"
+        },
+        {
+          "name": "QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/preprod/queue-url"
         }
       ]
     }

--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -66,6 +66,10 @@
         {
           "name": "SENTRY_DSN",
           "valueFrom": "tis-trainee-sync-sentry-dsn"
+        },
+        {
+          "name": "QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/prod/queue-url"
         }
       ]
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.11.0"
+version = "0.11.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,4 +21,4 @@ spring:
 application:
   aws:
     sqs:
-      queueUrl: ${QUEUE_URL:tis-trainee-sync-queue-preprod}
+      queueUrl: ${QUEUE_URL:}


### PR DESCRIPTION
Update application.yml to remove the default queue name to avoid
accidentally processing and removing entries when running the
application locally.

TIS21-1032