### PR TITLE
fix: Compound prog membership index name too long

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.11.1"
+version = "0.11.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
@@ -66,6 +66,8 @@ public class MongoConfiguration {
     keys.put("data.programmeMembershipType", 1);
     keys.put("data.programmeStartDate", 1);
     keys.put("data.programmeEndDate", 1);
-    programmeMembershipIndexOps.ensureIndex(new CompoundIndexDefinition(keys));
+    Index programmeMembershipCompoundIndex = new CompoundIndexDefinition(keys)
+        .named("programmeMembershipCompoundIndex");
+    programmeMembershipIndexOps.ensureIndex(programmeMembershipCompoundIndex);
   }
 }


### PR DESCRIPTION
The generated name for the programme membership compound index is too
long, provide a concise name that meets the restrictions.

TIS21-66