### PR TITLE
feat: update the cache before calling the enricher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.11.2"
+version = "0.11.3"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
@@ -32,9 +34,12 @@ import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 public class CurriculumEventListener extends AbstractMongoEventListener<Curriculum> {
 
   private final ProgrammeMembershipEnricherFacade programmeMembershipEnricher;
+  private final Cache cache;
 
-  CurriculumEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher) {
+  CurriculumEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher,
+      CacheManager cacheManager) {
     this.programmeMembershipEnricher = programmeMembershipEnricher;
+    cache = cacheManager.getCache(Curriculum.ENTITY_NAME);
   }
 
   @Override
@@ -42,6 +47,7 @@ public class CurriculumEventListener extends AbstractMongoEventListener<Curricul
     super.onAfterSave(event);
 
     Curriculum curriculum = event.getSource();
+    cache.put(curriculum.getTisId(), curriculum);
     programmeMembershipEnricher.enrich(curriculum);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
@@ -49,7 +49,7 @@ class CurriculumEventListenerTest {
     enricher = mock(ProgrammeMembershipEnricherFacade.class);
     cacheManager = mock(CacheManager.class);
     cache = mock(Cache.class);
-    when(cacheManager.getCache(eq(Curriculum.ENTITY_NAME))).thenReturn(cache);
+    when(cacheManager.getCache(Curriculum.ENTITY_NAME)).thenReturn(cache);
     listener = new CurriculumEventListener(enricher, cacheManager);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
@@ -21,34 +21,47 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 
 class CurriculumEventListenerTest {
 
+  private static final String TIS_ID = "5";
+
   private CurriculumEventListener listener;
   private ProgrammeMembershipEnricherFacade enricher;
+  private CacheManager cacheManager;
+  private Cache cache;
 
   @BeforeEach
   void setUp() {
     enricher = mock(ProgrammeMembershipEnricherFacade.class);
-    listener = new CurriculumEventListener(enricher);
+    cacheManager = mock(CacheManager.class);
+    cache = mock(Cache.class);
+    when(cacheManager.getCache(eq(Curriculum.ENTITY_NAME))).thenReturn(cache);
+    listener = new CurriculumEventListener(enricher, cacheManager);
   }
 
   @Test
   void shouldCallEnricherAfterSave() {
     Curriculum record = new Curriculum();
+    record.setTisId(TIS_ID);
     AfterSaveEvent<Curriculum> event = new AfterSaveEvent<>(record, null, null);
 
     listener.onAfterSave(event);
 
+    verify(cache).put(TIS_ID, record);
     verify(enricher).enrich(record);
     verifyNoMoreInteractions(enricher);
   }


### PR DESCRIPTION
The EventListener is invoked before the Caching proxy sees the successful save.
This leads to a stale cache value being used.

TIS21-66: Sync and display ProgrammeMemberships