### PR TITLE
fix: avoid NPE on delete of non-existent PM

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
@@ -88,6 +88,8 @@ public class ProgrammeMembershipEventListener
     super.onAfterDelete(event);
     ProgrammeMembership programmeMembership =
         programmeMembershipCache.get(event.getSource().getString("_id"), ProgrammeMembership.class);
-    programmeMembershipEnricher.delete(programmeMembership);
+    if (programmeMembership != null) {
+      programmeMembershipEnricher.delete(programmeMembership);
+    }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
@@ -122,4 +122,18 @@ class ProgrammeMembershipEventListenerTest {
     verify(mockEnricher).delete(record);
     verifyNoMoreInteractions(mockEnricher);
   }
+
+  @Test
+  void shouldNotCallFacadeDeleteIfNoProgrammeMembership() {
+    Document document = new Document();
+    document.append("_id", "1");
+    ProgrammeMembership record = new ProgrammeMembership();
+    AfterDeleteEvent<ProgrammeMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
+
+    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(null);
+
+    listener.onAfterDelete(eventAfter);
+
+    verifyNoInteractions(mockEnricher);
+  }
 }


### PR DESCRIPTION
Its a harmless error, but it looks ugly in the logs, e.g.:

2021-04-07 10:24:42.976  INFO 1 --- [io-8208-exec-10] u.n.h.t.trainee.sync.api.RecordResource  : REST request to process Record : RecordDto(data={id=284052, programmeMembershipType=SUBSTANTIVE, curriculumStartDate=2017-08-02, curriculumEndDate=2019-08-06, programmeStartDate=2017-08-02, programmeEndDate=2019-08-06, programmeId=761, curriculumId=487, trainingNumberId=1817, personId=120165, amendedDate=2021-03-10T15:14:54.895Z, trainingPathway=N/A}, metadata={timestamp=2021-03-31T11:03:51.122045Z, record-type=data, operation=delete, partition-key-type=schema-table, schema-name=tcs, table-name=ProgrammeMembership, transaction-id=11480454387235})
2021-04-07 10:24:42.976  INFO 1 --- [io-8208-exec-10] u.n.h.t.t.sync.service.RecordService     : Sync service found for table 'ProgrammeMembership' in 'tcs'
2021-04-07 10:24:42.976 DEBUG 1 --- [io-8208-exec-10] u.n.h.t.t.sync.service.RecordService     : Using sync service of type 'class uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService'.
2021-04-07 10:24:42.983 ERROR 1 --- [io-8208-exec-10] o.a.c.c.C.[.[.[.[dispatcherServlet]      : Servlet.service() for servlet [dispatcherServlet] in context with path [/sync] threw exception [Request processing failed; nested exception is java.lang.NullPointerException] with root cause
java.lang.NullPointerException: null