### PR TITLE
fix: Add DELETE status

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.14.0"
+version = "0.14.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/Status.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/Status.java
@@ -26,5 +26,6 @@ package uk.nhs.hee.tis.trainee.sync.dto;
  */
 public enum Status {
   CURRENT,
+  DELETE,
   INACTIVE
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
@@ -78,7 +78,7 @@ public class ReferenceSyncService implements SyncService {
     // Inactive records should be deleted.
     ReferenceDto dto = mapper.toReference(record);
     Operation operationType =
-        dto.getStatus() == Status.INACTIVE ? Operation.DELETE : record.getOperation();
+        dto.getStatus() != Status.CURRENT ? Operation.DELETE : record.getOperation();
 
     try {
       switch (operationType) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
@@ -45,6 +45,7 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.sync.dto.ReferenceDto;
+import uk.nhs.hee.tis.trainee.sync.dto.Status;
 import uk.nhs.hee.tis.trainee.sync.mapper.ReferenceMapperImpl;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
@@ -90,7 +91,8 @@ class ReferenceSyncServiceTest {
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
-        "label", "labelValue");
+        "label", "labelValue",
+        "status", "CURRENT");
     record.setData(data);
 
     service.syncRecord(record);
@@ -99,6 +101,7 @@ class ReferenceSyncServiceTest {
     expectedDto.setTisId("idValue");
     expectedDto.setAbbreviation("abbreviationValue");
     expectedDto.setLabel("labelValue");
+    expectedDto.setStatus(Status.CURRENT);
 
     verify(restTemplate).postForLocation(anyString(), eq(expectedDto), eq(apiName));
     verifyNoMoreInteractions(restTemplate);
@@ -113,7 +116,8 @@ class ReferenceSyncServiceTest {
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
-        "label", "labelValue");
+        "label", "labelValue",
+        "status", "CURRENT");
     record.setData(data);
 
     service.syncRecord(record);
@@ -122,6 +126,7 @@ class ReferenceSyncServiceTest {
     expectedDto.setTisId("idValue");
     expectedDto.setAbbreviation("abbreviationValue");
     expectedDto.setLabel("labelValue");
+    expectedDto.setStatus(Status.CURRENT);
 
     verify(restTemplate).postForLocation(anyString(), eq(expectedDto), eq(apiName));
     verifyNoMoreInteractions(restTemplate);
@@ -136,7 +141,8 @@ class ReferenceSyncServiceTest {
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
-        "label", "labelValue");
+        "label", "labelValue",
+        "status", "CURRENT");
     record.setData(data);
 
     service.syncRecord(record);
@@ -145,6 +151,7 @@ class ReferenceSyncServiceTest {
     expectedDto.setTisId("idValue");
     expectedDto.setAbbreviation("abbreviationValue");
     expectedDto.setLabel("labelValue");
+    expectedDto.setStatus(Status.CURRENT);
 
     verify(restTemplate).put(anyString(), eq(expectedDto), eq(apiName));
     verifyNoMoreInteractions(restTemplate);
@@ -178,6 +185,20 @@ class ReferenceSyncServiceTest {
     verifyNoMoreInteractions(restTemplate);
   }
 
+  @ParameterizedTest(name = "Should delete record when operation is {0} and status is DELETE")
+  @EnumSource(Operation.class)
+  void shouldDeleteRecordWhenStatusIsDelete(Operation operation) {
+    record.setTisId("40");
+    record.setTable("Grade");
+    record.setOperation(operation);
+    record.setData(Collections.singletonMap("status", "DELETE"));
+
+    service.syncRecord(record);
+
+    verify(restTemplate).delete(anyString(), eq("grade"), eq("40"));
+    verifyNoMoreInteractions(restTemplate);
+  }
+
   @Test
   void shouldNotThrowWhenValidationFails() {
     record.setTisId("40");
@@ -197,6 +218,7 @@ class ReferenceSyncServiceTest {
     record.setTisId("40");
     record.setTable("Grade");
     record.setOperation(Operation.LOAD);
+    record.setData(Collections.singletonMap("status", "CURRENT"));
 
     HttpClientErrorException exception = new HttpClientErrorException(
         HttpStatus.UNSUPPORTED_MEDIA_TYPE);


### PR DESCRIPTION
Curriculum sync is failing as some records have "DELETE" as the status,
which is not accounted for.

TIS21-1451