### PR TITLE
fix: Handle incorrect required role casing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.14.1"
+version = "0.14.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -187,12 +187,12 @@ public class TcsSyncService implements SyncService {
    * @param record The record to verify.
    * @return Whether the required role was found.
    */
-  public boolean hasRequiredRoleForProfileCreation(Record record) {
+  private boolean hasRequiredRoleForProfileCreation(Record record) {
     String concatRoles = record.getData().getOrDefault("role", "");
     String[] roles = concatRoles.split(",");
 
     for (String role : roles) {
-      if (role.equals(REQUIRED_ROLE)) {
+      if (role.equalsIgnoreCase(REQUIRED_ROLE)) {
         return true;
       }
     }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -152,25 +152,20 @@ class TcsSyncServiceTest {
     service.syncRecord(record);
 
     verifyNoInteractions(restTemplate);
-    verify(personService,times(1)).findById(anyString());
+    verify(personService, times(1)).findById(anyString());
   }
 
   @ParameterizedTest(
       name = "Should patch basic details when role is {0}, operation is load and table is Person")
-  @ValueSource(strings = {"roleBefore," + REQUIRED_ROLE, REQUIRED_ROLE,
+  @ValueSource(strings = {"Dr in Training", "roleBefore," + REQUIRED_ROLE, REQUIRED_ROLE,
       REQUIRED_ROLE + ",roleAfter", "roleBefore," + REQUIRED_ROLE + ",roleAfter"})
   void shouldPatchBasicDetailsWhenRequiredRoleFound(String role) {
-
     Person record = new Person();
     record.setTisId("idValue");
     record.setTable("Person");
     record.setOperation(INSERT);
     data.put("role", role);
     record.setData(data);
-
-    Optional<Person> person = Optional.of(new Person());
-
-    when(personService.findById("idValue")).thenReturn(person);
 
     service.syncRecord(record);
 
@@ -439,7 +434,7 @@ class TcsSyncServiceTest {
         .delete(anyString(), eq("placement"), eq("traineeIdValue"), eq("idValue"));
     verifyNoMoreInteractions(restTemplate);
   }
-  
+
   @ParameterizedTest(name = "Should not delete when operation is DELETE and table is {0}")
   @ValueSource(strings = {"ContactDetails", "GdcDetails", "GmcDetails", "Person", "PersonOwner",
       "PersonalDetails", "Qualification", "Curriculum"})


### PR DESCRIPTION
Some trainees have the role `Dr in Training` instead of `DR in
Training`, these profiles are not properly synced. Ignore the casing
when comparing the role to ensure we catch edge cases.

TIS21-1624