### PR TITLE
chore: Update preprod log group name

### DIFF
--- a/.aws/task-definition-pre-prod.json
+++ b/.aws/task-definition-pre-prod.json
@@ -25,7 +25,7 @@
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
-          "awslogs-group": "awslogs-tis-trainee-sync",
+          "awslogs-group": "awslogs-preprod-tis-trainee-sync",
           "awslogs-region": "eu-west-2",
           "awslogs-stream-prefix": "awslogs-tis-trainee-sync"
         }


### PR DESCRIPTION
Update the preprod log group name to meet the current conventions.

TIS21-1665