### PR TITLE
fix: Handle non-data DMS records

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.18.2"
+version = "0.18.3"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
@@ -28,6 +28,7 @@ import uk.nhs.hee.tis.trainee.sync.dto.RecordDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil.Id;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil.Operation;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil.RecordType;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil.Schema;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.RecordUtil.Table;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
@@ -37,6 +38,7 @@ public interface RecordMapper {
 
   @Mapping(target = "tisId", source = "data", qualifiedBy = Id.class)
   @Mapping(target = "operation", source = "metadata", qualifiedBy = Operation.class)
+  @Mapping(target = "type", source = "metadata", qualifiedBy = RecordType.class)
   @Mapping(target = "schema", source = "metadata", qualifiedBy = Schema.class)
   @Mapping(target = "table", source = "metadata", qualifiedBy = Table.class)
   Record toEntity(RecordDto recordDto);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/RecordUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/RecordUtil.java
@@ -50,6 +50,13 @@ public class RecordUtil {
   @Qualifier
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.SOURCE)
+  public @interface RecordType {
+
+  }
+
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
   public @interface Schema {
 
   }
@@ -74,12 +81,31 @@ public class RecordUtil {
    */
   @Operation
   public uk.nhs.hee.tis.trainee.sync.model.Operation operation(Map<String, String> metadata) {
-    String operation = metadata.get("operation");
-    return Arrays.stream(uk.nhs.hee.tis.trainee.sync.model.Operation.values())
-        .filter(e -> e.name().equalsIgnoreCase(operation))
+    String operationString = metadata.get("operation");
+    var operation = uk.nhs.hee.tis.trainee.sync.model.Operation.fromString(operationString);
+
+    if (operation == null) {
+      throw new IllegalArgumentException(
+          String.format("Unhandled record operation '%s'.", operationString));
+    }
+
+    return operation;
+  }
+
+  /**
+   * Finds the RecordType enum value from the metadata.
+   *
+   * @param metadata the metadata map
+   * @return the RecordType value
+   */
+  @RecordType
+  public uk.nhs.hee.tis.trainee.sync.model.RecordType recordType(Map<String, String> metadata) {
+    String recordType = metadata.get("record-type");
+    return Arrays.stream(uk.nhs.hee.tis.trainee.sync.model.RecordType.values())
+        .filter(e -> e.name().equalsIgnoreCase(recordType))
         .findAny()
         .orElseThrow(() -> new IllegalArgumentException(
-            String.format("Unhandled record operation '%s'.", operation)));
+            String.format("Unhandled record type '%s'.", recordType)));
   }
 
   @Schema

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Operation.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Operation.java
@@ -1,9 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package uk.nhs.hee.tis.trainee.sync.model;
 
 public enum Operation {
-    UPDATE,
-    INSERT,
-    DELETE,
-    LOAD
-}
+  UPDATE("update"),
+  INSERT("insert"),
+  DELETE("delete"),
+  LOAD("load"),
+  DROP_TABLE("drop-table"),
+  CREATE_TABLE("create-table");
 
+
+  private final String key;
+
+  Operation(String key) {
+    this.key = key;
+  }
+
+  public static Operation fromString(String key) {
+    for (Operation operation : values()) {
+      if (operation.key.equalsIgnoreCase(key)) {
+        return operation;
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
@@ -38,6 +38,9 @@ public class Record {
   private Map<String, String> metadata = new HashMap<>();
 
   @Transient
+  private RecordType type;
+
+  @Transient
   private Operation operation;
 
   @Transient

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/RecordType.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/RecordType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2021 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,18 +19,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.tis.trainee.sync.dto;
+package uk.nhs.hee.tis.trainee.sync.model;
 
-import java.util.Collections;
-import java.util.Map;
-import javax.validation.constraints.NotNull;
-import lombok.Data;
-
-@Data
-public class RecordDto {
-
-  private Map<String, String> data = Collections.emptyMap();
-
-  @NotNull
-  private Map<String, String> metadata;
+public enum RecordType {
+  CONTROL,
+  DATA
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.dto.RecordDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.RecordMapper;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.model.RecordType;
 
 @Slf4j
 @Service
@@ -49,6 +50,13 @@ public class RecordService {
    */
   public void processRecord(RecordDto recordDto) {
     Record record = convertToRecord(recordDto);
+
+    if (record.getType().equals(RecordType.CONTROL)) {
+      log.info("Skipping non-data record with operation '{}' on '{}.{}'.", record.getOperation(),
+          record.getSchema(), record.getTable());
+      return;
+    }
+
     String schema = record.getSchema();
 
     try {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/RecordServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/RecordServiceTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
@@ -64,12 +65,38 @@ class RecordServiceTest {
   }
 
   @Test
+  void shouldThrowExceptionWhenRecordTypeIsNull() {
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(Collections.emptyMap());
+    recordDto.setMetadata(
+        Map.of("schema-name", "testSchema", "table-name", "testTable", "operation", "update"));
+
+    assertThrows(IllegalArgumentException.class, () -> service.processRecord(recordDto));
+  }
+
+  @Test
   void shouldThrowExceptionWhenOperationIsNull() {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
-    recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name", "testTable"));
+    recordDto.setMetadata(
+        Map.of("schema-name", "testSchema", "table-name", "testTable", "record-type", "data"));
 
     assertThrows(IllegalArgumentException.class, () -> service.processRecord(recordDto));
+  }
+
+  @Test
+  void shouldSkipRecordWhenRecordTypeIsControl() {
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(Collections.emptyMap());
+    recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name",
+        "testTable", "operation", "update", "record-type", "control"));
+
+    when(context.getBean("testTable", Record.class)).thenReturn(new Record());
+
+    service.processRecord(recordDto);
+
+    verify(context).getBean("testTable", Record.class);
+    verifyNoMoreInteractions(context);
   }
 
   @Test
@@ -77,7 +104,7 @@ class RecordServiceTest {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
     recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name",
-        "testTable", "operation", "update"));
+        "testTable", "operation", "update", "record-type", "data"));
 
     when(context.getBean("testTable", Record.class)).thenReturn(new Record());
 
@@ -99,7 +126,8 @@ class RecordServiceTest {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
     recordDto.setMetadata(
-        Map.of("schema-name", "testSchema", "table-name", "testTable", "operation", "load"));
+        Map.of("schema-name", "testSchema", "table-name", "testTable", "operation", "load",
+            "record-type", "data"));
 
     when(context.getBean("testTable", Record.class)).thenReturn(new Record());
 
@@ -123,7 +151,7 @@ class RecordServiceTest {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
     recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name",
-        "testTable", "operation", "load"));
+        "testTable", "operation", "load", "record-type", "data"));
 
     when(context.getBean("testTable", Record.class)).thenReturn(new Record());
 
@@ -140,7 +168,7 @@ class RecordServiceTest {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
     recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name",
-        "testTable", "operation", "delete"));
+        "testTable", "operation", "delete", "record-type", "data"));
 
     Placement placement = new Placement();
 
@@ -166,7 +194,7 @@ class RecordServiceTest {
     RecordDto recordDto = new RecordDto();
     recordDto.setData(Collections.emptyMap());
     recordDto.setMetadata(Map.of("schema-name", "testSchema", "table-name",
-        "testTable", "operation", "insert"));
+        "testTable", "operation", "insert", "record-type", "data"));
 
     when(context.getBean("testTable", Record.class))
         .thenThrow(new NoSuchBeanDefinitionException("Expected exception."));


### PR DESCRIPTION
Some DMS records are sent with a record type of `control`, these records
notify of important events in the stream such as creating a table.

Control records contain no `data` so the record data map must be allowed
to be null.

Nothing needs to be done when receiving a control record, so processing
should be skipped but it should not cause an exception.

TIS21-1919