### PR TITLE
refactor: Rename `record` variables

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapper.java
@@ -42,5 +42,5 @@ public interface ReferenceMapper {
   @Mapping(target = "placementGrade", source = "data", qualifiedBy = PlacementGrade.class)
   @Mapping(target = "trainingGrade", source = "data", qualifiedBy = TrainingGrade.class)
   @Mapping(target = "curriculumSubType", source = "data", qualifiedBy = CurriculumSubType.class)
-  ReferenceDto toReference(Record record);
+  ReferenceDto toReference(Record recrd);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -85,7 +85,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
   @Mapping(target = "publicHealthNumber", source = "data", qualifiedBy = PublicHealthNumber.class)
-  TraineeDetailsDto toBasicDetailsDto(Record record);
+  TraineeDetailsDto toBasicDetailsDto(Record recrd);
 
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
@@ -102,36 +102,36 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "address3", source = "data", qualifiedBy = Address3.class)
   @Mapping(target = "address4", source = "data", qualifiedBy = Address4.class)
   @Mapping(target = "postCode", source = "data", qualifiedBy = PostCode.class)
-  TraineeDetailsDto toContactDetails(Record record);
+  TraineeDetailsDto toContactDetails(Record recrd);
 
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
   @Mapping(target = "gdcNumber", source = "data", qualifiedBy = GdcNumber.class)
   @Mapping(target = "gdcStatus", source = "data", qualifiedBy = GdcStatus.class)
-  TraineeDetailsDto toGdcDetailsDto(Record record);
+  TraineeDetailsDto toGdcDetailsDto(Record recrd);
 
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
   @Mapping(target = "gmcNumber", source = "data", qualifiedBy = GmcNumber.class)
   @Mapping(target = "gmcStatus", source = "data", qualifiedBy = GmcStatus.class)
-  TraineeDetailsDto toGmcDetailsDto(Record record);
+  TraineeDetailsDto toGmcDetailsDto(Record recrd);
 
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
   @Mapping(target = "personOwner", source = "data", qualifiedBy = Owner.class)
-  TraineeDetailsDto toPersonOwnerDto(Record record);
+  TraineeDetailsDto toPersonOwnerDto(Record recrd);
 
   @Mapping(target = "tisId", ignore = true)
   @Mapping(target = "traineeTisId", source = "tisId")
   @Mapping(target = "dateOfBirth", source = "data", qualifiedBy = DateOfBirth.class)
   @Mapping(target = "gender", source = "data", qualifiedBy = Gender.class)
-  TraineeDetailsDto toPersonalInfoDto(Record record);
+  TraineeDetailsDto toPersonalInfoDto(Record recrd);
 
   @Mapping(target = "traineeTisId", source = "data", qualifiedBy = PersonId.class)
   @Mapping(target = "qualification", source = "data", qualifiedBy = Qualification.class)
   @Mapping(target = "dateAttained", source = "data", qualifiedBy = DateAttained.class)
   @Mapping(target = "medicalSchool", source = "data", qualifiedBy = MedicalSchool.class)
-  TraineeDetailsDto toQualificationDto(Record record);
+  TraineeDetailsDto toQualificationDto(Record recrd);
 
   @Mapping(target = "traineeTisId", source = "data", qualifiedBy = TraineeId.class)
   @Mapping(target = "startDate", source = "data", qualifiedBy = StartDate.class)
@@ -146,7 +146,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "specialty", source = "data", qualifiedBy = Specialty.class)
   @Mapping(target = "wholeTimeEquivalent", source = "data",
       qualifiedBy = PlacementWholeTimeEquivalent.class)
-  TraineeDetailsDto toPlacementDto(Record record);
+  TraineeDetailsDto toPlacementDto(Record recrd);
 
   @Mapping(target = "traineeTisId", source = "data", qualifiedBy = PersonId.class)
   @Mapping(target = "startDate", source = "data", qualifiedBy = ProgrammeStartDate.class)
@@ -160,11 +160,11 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "programmeCompletionDate", source = "data",
       qualifiedBy = ProgrammeCompletionDate.class)
   @Mapping(target = "curricula", source = "data", qualifiedBy = Curricula.class)
-  TraineeDetailsDto toProgrammeMembershipDto(Record record);
+  TraineeDetailsDto toProgrammeMembershipDto(Record recrd);
 
   @Mapping(target = "curriculumName", source = "data", qualifiedBy = CurriculumName.class)
   @Mapping(target = "curriculumSubType", source = "data", qualifiedBy = CurriculumSubType.class)
   @Mapping(target = "curriculumStartDate", source = "data", qualifiedBy = CurriculumStartDate.class)
   @Mapping(target = "curriculumEndDate", source = "data", qualifiedBy = CurriculumEndDate.class)
-  TraineeDetailsDto toCurriculumDto(Record record);
+  TraineeDetailsDto toCurriculumDto(Record recrd);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumSyncService.java
@@ -54,23 +54,23 @@ public class CurriculumSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Curriculum)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record curriculum) {
+    if (!(curriculum instanceof Curriculum)) {
+      String message = String.format("Invalid record type '%s'.", curriculum.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (curriculum.getOperation().equals(DELETE)) {
+      repository.deleteById(curriculum.getTisId());
     } else {
-      repository.save((Curriculum) record);
+      repository.save((Curriculum) curriculum);
     }
 
-    String id = record.getTisId();
+    String id = curriculum.getTisId();
     requestedIds.remove(id);
 
     // Send the record to the reference sync service to also be handled as a reference data type.
-    referenceSyncService.syncRecord(record);
+    referenceSyncService.syncRecord(curriculum);
   }
 
   public Optional<Curriculum> findById(String id) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
@@ -30,29 +30,29 @@ public class PlacementSpecialtySyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof PlacementSpecialty)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record placementSpecialty) {
+    if (!(placementSpecialty instanceof PlacementSpecialty)) {
+      String message = String.format("Invalid record type '%s'.", placementSpecialty.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      String placementId = record.getData().get(PLACEMENT_ID);
+    if (placementSpecialty.getOperation().equals(DELETE)) {
+      String placementId = placementSpecialty.getData().get(PLACEMENT_ID);
       Optional<PlacementSpecialty> storedPlacementSpecialty = repository.findById(placementId);
-      if (storedPlacementSpecialty.isEmpty() || haveSameSpecialtyIds(record,
+      if (storedPlacementSpecialty.isEmpty() || haveSameSpecialtyIds(placementSpecialty,
           storedPlacementSpecialty.get())) {
         repository.deleteById(placementId);
       }
     } else {
-      if (Objects.equals(record.getData().get("placementSpecialtyType"), "PRIMARY")) {
-        Map<String, String> placementSpecialtyData = record.getData();
+      if (Objects.equals(placementSpecialty.getData().get("placementSpecialtyType"), "PRIMARY")) {
+        Map<String, String> placementSpecialtyData = placementSpecialty.getData();
         String placementId = placementSpecialtyData.get(PLACEMENT_ID);
-        record.setTisId(placementId);
-        repository.save((PlacementSpecialty) record);
+        placementSpecialty.setTisId(placementId);
+        repository.save((PlacementSpecialty) placementSpecialty);
       }
     }
 
-    String id = record.getTisId();
+    String id = placementSpecialty.getTisId();
     requestedIds.remove(id);
   }
 
@@ -87,9 +87,9 @@ public class PlacementSpecialtySyncService implements SyncService {
     }
   }
 
-  private boolean haveSameSpecialtyIds(Record record, PlacementSpecialty placementSpecialty) {
-    return Objects.equals(record.getData().get("specialtyId"),
-        placementSpecialty.getData().get("specialtyId"));
+  private boolean haveSameSpecialtyIds(Record placementSpecialty,
+      PlacementSpecialty storedPlacementSpecialty) {
+    return Objects.equals(placementSpecialty.getData().get("specialtyId"),
+        storedPlacementSpecialty.getData().get("specialtyId"));
   }
-
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncService.java
@@ -60,14 +60,14 @@ public class PlacementSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Placement)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record placement) {
+    if (!(placement instanceof Placement)) {
+      String message = String.format("Invalid record type '%s'.", placement.getClass());
       throw new IllegalArgumentException(message);
     }
 
     // Send incoming placement records to the placement queue to be processed.
-    messagingTemplate.convertAndSend(queueUrl, record);
+    messagingTemplate.convertAndSend(queueUrl, placement);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncService.java
@@ -50,19 +50,19 @@ public class PostSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Post)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record post) {
+    if (!(post instanceof Post)) {
+      String message = String.format("Invalid record type '%s'.", post.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (post.getOperation().equals(DELETE)) {
+      repository.deleteById(post.getTisId());
     } else {
-      repository.save((Post) record);
+      repository.save((Post) post);
     }
 
-    String id = record.getTisId();
+    String id = post.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncService.java
@@ -51,19 +51,19 @@ public class ProgrammeMembershipSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof ProgrammeMembership)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record programmeMembership) {
+    if (!(programmeMembership instanceof ProgrammeMembership)) {
+      String message = String.format("Invalid record type '%s'.", programmeMembership.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (programmeMembership.getOperation().equals(DELETE)) {
+      repository.deleteById(programmeMembership.getTisId());
     } else {
-      repository.save((ProgrammeMembership) record);
+      repository.save((ProgrammeMembership) programmeMembership);
     }
 
-    String id = record.getTisId();
+    String id = programmeMembership.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeSyncService.java
@@ -50,19 +50,19 @@ public class ProgrammeSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Programme)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record programme) {
+    if (!(programme instanceof Programme)) {
+      String message = String.format("Invalid record type '%s'.", programme.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (programme.getOperation().equals(DELETE)) {
+      repository.deleteById(programme.getTisId());
     } else {
-      repository.save((Programme) record);
+      repository.save((Programme) programme);
     }
 
-    String id = record.getTisId();
+    String id = programme.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
@@ -49,19 +49,19 @@ public class RecordService {
    * @param recordDto The record to process.
    */
   public void processRecord(RecordDto recordDto) {
-    Record record = convertToRecord(recordDto);
+    Record recrd = convertToRecord(recordDto);
 
-    if (record.getType().equals(RecordType.CONTROL)) {
-      log.info("Skipping non-data record with operation '{}' on '{}.{}'.", record.getOperation(),
-          record.getSchema(), record.getTable());
+    if (recrd.getType().equals(RecordType.CONTROL)) {
+      log.info("Skipping non-data record with operation '{}' on '{}.{}'.", recrd.getOperation(),
+          recrd.getSchema(), recrd.getTable());
       return;
     }
 
-    String schema = record.getSchema();
+    String schema = recrd.getSchema();
 
     try {
-      SyncService service = getSyncService(record);
-      service.syncRecord(record);
+      SyncService service = getSyncService(recrd);
+      service.syncRecord(recrd);
     } catch (BeansException e) {
       log.warn("Unhandled record schema '{}'.", schema);
     }
@@ -91,14 +91,14 @@ public class RecordService {
    * Get the sync service for the given record, the closest appropriate service is selected based on
    * the schema and table of the record.
    *
-   * @param record The record to get the service for.
+   * @param recrd The record to get the service for.
    * @return The discovered sync service.
    * @throws BeansException When no appropriate service was found.
    */
-  private SyncService getSyncService(Record record) throws BeansException {
+  private SyncService getSyncService(Record recrd) throws BeansException {
     SyncService service;
-    String schema = record.getSchema();
-    String table = record.getTable();
+    String schema = recrd.getSchema();
+    String table = recrd.getTable();
 
     try {
       String schemaTable = String.format("%s-%s", schema, table);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
@@ -68,17 +68,17 @@ public class ReferenceSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    Optional<String> referenceType = getReferenceType(record);
+  public void syncRecord(Record recrd) {
+    Optional<String> referenceType = getReferenceType(recrd);
 
     if (referenceType.isEmpty()) {
       return;
     }
 
     // Inactive records should be deleted.
-    ReferenceDto dto = mapper.toReference(record);
+    ReferenceDto dto = mapper.toReference(recrd);
     Operation operationType =
-        dto.getStatus() != Status.CURRENT ? Operation.DELETE : record.getOperation();
+        dto.getStatus() != Status.CURRENT ? Operation.DELETE : recrd.getOperation();
 
     try {
       switch (operationType) {
@@ -107,11 +107,11 @@ public class ReferenceSyncService implements SyncService {
   /**
    * Get the reference type based on the {@link Record}.
    *
-   * @param record The record to get the reference type of.
+   * @param recrd The record to get the reference type of.
    * @return An optional reference type, empty if a supported table is not found.
    */
-  private Optional<String> getReferenceType(Record record) {
-    String table = record.getTable();
+  private Optional<String> getReferenceType(Record recrd) {
+    String table = recrd.getTable();
     String referenceType = TABLE_NAME_TO_REFERENCE_TYPE.get(table);
 
     if (referenceType == null) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncService.java
@@ -50,19 +50,19 @@ public class SiteSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Site)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record site) {
+    if (!(site instanceof Site)) {
+      String message = String.format("Invalid record type '%s'.", site.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (site.getOperation().equals(DELETE)) {
+      repository.deleteById(site.getTisId());
     } else {
-      repository.save((Site) record);
+      repository.save((Site) site);
     }
 
-    String id = record.getTisId();
+    String id = site.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncService.java
@@ -29,19 +29,19 @@ public class SpecialtySyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Specialty)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record specialty) {
+    if (!(specialty instanceof Specialty)) {
+      String message = String.format("Invalid record type '%s'.", specialty.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (specialty.getOperation().equals(DELETE)) {
+      repository.deleteById(specialty.getTisId());
     } else {
-      repository.save((Specialty) record);
+      repository.save((Specialty) specialty);
     }
 
-    String id = record.getTisId();
+    String id = specialty.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SyncService.java
@@ -32,7 +32,7 @@ public interface SyncService {
   /**
    * Synchronize the given record by calling the appropriate API.
    *
-   * @param record The record to synchronize.
+   * @param recrd The record to synchronize.
    */
-  void syncRecord(Record record);
+  void syncRecord(Record recrd);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -98,20 +98,20 @@ public class TcsSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    Optional<String> apiPath = getApiPath(record);
+  public void syncRecord(Record recrd) {
+    Optional<String> apiPath = getApiPath(recrd);
 
     if (apiPath.isEmpty()) {
       return;
     }
 
-    TraineeDetailsDto dto = tableNameToMappingFunction.get(record.getTable()).apply(record);
+    TraineeDetailsDto dto = tableNameToMappingFunction.get(recrd.getTable()).apply(recrd);
 
     boolean doSync;
 
-    if (record instanceof Person && !findById(dto.getTraineeTisId())) {
-      if (hasRequiredRoleForProfileCreation(record)) {
-        personService.save((Person) record);
+    if (recrd instanceof Person && !findById(dto.getTraineeTisId())) {
+      if (hasRequiredRoleForProfileCreation(recrd)) {
+        personService.save((Person) recrd);
         doSync = true;
       } else {
         log.info("Trainee with id{} did not have the required role '{}'.", dto.getTraineeTisId(),
@@ -123,7 +123,7 @@ public class TcsSyncService implements SyncService {
     }
 
     if (doSync) {
-      Operation operationType = record.getOperation();
+      Operation operationType = recrd.getOperation();
       syncDetails(dto, apiPath.get(), operationType);
     }
   }
@@ -167,11 +167,11 @@ public class TcsSyncService implements SyncService {
   /**
    * Get the API path based on the {@link Record}.
    *
-   * @param record The record to get the API path for.
+   * @param recrd The record to get the API path for.
    * @return An optional API path, empty if a supported table is not found.
    */
-  private Optional<String> getApiPath(Record record) {
-    String table = record.getTable();
+  private Optional<String> getApiPath(Record recrd) {
+    String table = recrd.getTable();
     String apiPath = TABLE_NAME_TO_API_PATH.get(table);
 
     if (apiPath == null) {
@@ -184,11 +184,11 @@ public class TcsSyncService implements SyncService {
   /**
    * Checks whether the Person record has the required role for a profile record to be created.
    *
-   * @param record The record to verify.
+   * @param recrd The record to verify.
    * @return Whether the required role was found.
    */
-  private boolean hasRequiredRoleForProfileCreation(Record record) {
-    String concatRoles = record.getData().getOrDefault("role", "");
+  private boolean hasRequiredRoleForProfileCreation(Record recrd) {
+    String concatRoles = recrd.getData().getOrDefault("role", "");
     String[] roles = concatRoles.split(",");
 
     for (String role : roles) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncService.java
@@ -51,19 +51,19 @@ public class TrustSyncService implements SyncService {
   }
 
   @Override
-  public void syncRecord(Record record) {
-    if (!(record instanceof Trust)) {
-      String message = String.format("Invalid record type '%s'.", record.getClass());
+  public void syncRecord(Record trust) {
+    if (!(trust instanceof Trust)) {
+      String message = String.format("Invalid record type '%s'.", trust.getClass());
       throw new IllegalArgumentException(message);
     }
 
-    if (record.getOperation().equals(DELETE)) {
-      repository.deleteById(record.getTisId());
+    if (trust.getOperation().equals(DELETE)) {
+      repository.deleteById(trust.getTisId());
     } else {
-      repository.save((Trust) record);
+      repository.save((Trust) trust);
     }
 
-    String id = record.getTisId();
+    String id = trust.getTisId();
     requestedIds.remove(id);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -55,14 +54,14 @@ class CurriculumEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    Curriculum record = new Curriculum();
-    record.setTisId(TIS_ID);
-    AfterSaveEvent<Curriculum> event = new AfterSaveEvent<>(record, null, null);
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(TIS_ID);
+    AfterSaveEvent<Curriculum> event = new AfterSaveEvent<>(curriculum, null, null);
 
     listener.onAfterSave(event);
 
-    verify(cache).put(TIS_ID, record);
-    verify(enricher).enrich(record);
+    verify(cache).put(TIS_ID, curriculum);
+    verify(enricher).enrich(curriculum);
     verifyNoMoreInteractions(enricher);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementEventListenerTest.java
@@ -61,12 +61,12 @@ class PlacementEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    Placement record = new Placement();
-    AfterSaveEvent<Placement> event = new AfterSaveEvent<>(record, null, null);
+    Placement placement = new Placement();
+    AfterSaveEvent<Placement> event = new AfterSaveEvent<>(placement, null, null);
 
     listener.onAfterSave(event);
 
-    verify(mockEnricher).enrich(record);
+    verify(mockEnricher).enrich(placement);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -74,16 +74,16 @@ class PlacementEventListenerTest {
   void shouldFindAndCachePlacementIfNotInCacheBeforeDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    Placement record = new Placement();
+    Placement placement = new Placement();
     BeforeDeleteEvent<Placement> event = new BeforeDeleteEvent<>(document, null, null);
 
     when(mockCache.get("1", Placement.class)).thenReturn(null);
-    when(mockPlacementSyncService.findById(anyString())).thenReturn(Optional.of(record));
+    when(mockPlacementSyncService.findById(anyString())).thenReturn(Optional.of(placement));
 
     listener.onBeforeDelete(event);
 
     verify(mockPlacementSyncService).findById("1");
-    verify(mockCache).put("1", record);
+    verify(mockCache).put("1", placement);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -91,10 +91,10 @@ class PlacementEventListenerTest {
   void shouldNotFindAndCachePlacementIfInCacheBeforeDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    Placement record = new Placement();
+    Placement placement = new Placement();
     BeforeDeleteEvent<Placement> event = new BeforeDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", Placement.class)).thenReturn(record);
+    when(mockCache.get("1", Placement.class)).thenReturn(placement);
 
     listener.onBeforeDelete(event);
 
@@ -106,14 +106,14 @@ class PlacementEventListenerTest {
   void shouldCallFacadeDeleteAfterDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    Placement record = new Placement();
+    Placement placement = new Placement();
     AfterDeleteEvent<Placement> eventAfter = new AfterDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", Placement.class)).thenReturn(record);
+    when(mockCache.get("1", Placement.class)).thenReturn(placement);
 
     listener.onAfterDelete(eventAfter);
 
-    verify(mockEnricher).delete(record);
+    verify(mockEnricher).delete(placement);
     verifyNoMoreInteractions(mockEnricher);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
@@ -46,12 +46,12 @@ class PlacementSpecialtyEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    PlacementSpecialty record = new PlacementSpecialty();
-    AfterSaveEvent<PlacementSpecialty> event = new AfterSaveEvent<>(record, null, null);
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+    AfterSaveEvent<PlacementSpecialty> event = new AfterSaveEvent<>(placementSpecialty, null, null);
 
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(record);
+    verify(enricher).enrich(placementSpecialty);
     verifyNoMoreInteractions(enricher);
   }
 
@@ -65,7 +65,6 @@ class PlacementSpecialtyEventListenerTest {
     verify(enricher).restartPlacementEnrichmentIfDeletionIncorrect("40");
     verifyNoMoreInteractions(enricher);
   }
-
 
 
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
@@ -44,12 +44,12 @@ class ProgrammeEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    Programme record = new Programme();
-    AfterSaveEvent<Programme> event = new AfterSaveEvent<>(record, null, null);
+    Programme programme = new Programme();
+    AfterSaveEvent<Programme> event = new AfterSaveEvent<>(programme, null, null);
 
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(record);
+    verify(enricher).enrich(programme);
     verifyNoMoreInteractions(enricher);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
@@ -67,12 +67,13 @@ class ProgrammeMembershipEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    ProgrammeMembership record = new ProgrammeMembership();
-    AfterSaveEvent<ProgrammeMembership> event = new AfterSaveEvent<>(record, null, null);
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    AfterSaveEvent<ProgrammeMembership> event = new AfterSaveEvent<>(programmeMembership, null,
+        null);
 
     listener.onAfterSave(event);
 
-    verify(mockEnricher).enrich(record);
+    verify(mockEnricher).enrich(programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -80,16 +81,17 @@ class ProgrammeMembershipEventListenerTest {
   void shouldFindAndCacheProgrammeMembershipIfNotInCacheBeforeDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    ProgrammeMembership record = new ProgrammeMembership();
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
     BeforeDeleteEvent<ProgrammeMembership> event = new BeforeDeleteEvent<>(document, null, null);
 
     when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(null);
-    when(mockProgrammeMembershipSyncService.findById(anyString())).thenReturn(Optional.of(record));
+    when(mockProgrammeMembershipSyncService.findById(anyString()))
+        .thenReturn(Optional.of(programmeMembership));
 
     listener.onBeforeDelete(event);
 
     verify(mockProgrammeMembershipSyncService).findById("1");
-    verify(mockCache).put("1", record);
+    verify(mockCache).put("1", programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -97,10 +99,10 @@ class ProgrammeMembershipEventListenerTest {
   void shouldNotFindAndCacheProgrammeMembershipIfInCacheBeforeDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    ProgrammeMembership record = new ProgrammeMembership();
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
     BeforeDeleteEvent<ProgrammeMembership> event = new BeforeDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(record);
+    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(programmeMembership);
 
     listener.onBeforeDelete(event);
 
@@ -112,14 +114,14 @@ class ProgrammeMembershipEventListenerTest {
   void shouldCallFacadeDeleteAfterDelete() {
     Document document = new Document();
     document.append("_id", "1");
-    ProgrammeMembership record = new ProgrammeMembership();
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
     AfterDeleteEvent<ProgrammeMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(record);
+    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(programmeMembership);
 
     listener.onAfterDelete(eventAfter);
 
-    verify(mockEnricher).delete(record);
+    verify(mockEnricher).delete(programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -127,7 +129,6 @@ class ProgrammeMembershipEventListenerTest {
   void shouldNotCallFacadeDeleteIfNoProgrammeMembership() {
     Document document = new Document();
     document.append("_id", "1");
-    ProgrammeMembership record = new ProgrammeMembership();
     AfterDeleteEvent<ProgrammeMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
 
     when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(null);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/RecordListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/RecordListenerTest.java
@@ -49,10 +49,10 @@ class RecordListenerTest {
   @Disabled("Unable to get the validation working during tests.")
   @Test
   void shouldNotProcessRecordWhenDataNull() {
-    RecordDto record = new RecordDto();
-    record.setMetadata(Collections.emptyMap());
+    RecordDto recordDto = new RecordDto();
+    recordDto.setMetadata(Collections.emptyMap());
 
-    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(record));
+    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(recordDto));
 
     verifyNoInteractions(service);
   }
@@ -60,10 +60,10 @@ class RecordListenerTest {
   @Disabled("Unable to get the validation working during tests.")
   @Test
   void shouldNotProcessRecordWhenMetadataNull() {
-    RecordDto record = new RecordDto();
-    record.setData(Collections.emptyMap());
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(Collections.emptyMap());
 
-    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(record));
+    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(recordDto));
 
     verifyNoInteractions(service);
   }
@@ -71,21 +71,21 @@ class RecordListenerTest {
   @Disabled("Unable to get the validation working during tests.")
   @Test
   void shouldNotProcessRecordWhenDataAndMetadataNull() {
-    RecordDto record = new RecordDto();
+    RecordDto recordDto = new RecordDto();
 
-    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(record));
+    assertThrows(ConstraintViolationException.class, () -> listener.getRecord(recordDto));
 
     verifyNoInteractions(service);
   }
 
   @Test
   void shouldProcessRecordWhenDataAndMetadataNotNull() {
-    RecordDto record = new RecordDto();
-    record.setData(Collections.emptyMap());
-    record.setMetadata(Collections.emptyMap());
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(Collections.emptyMap());
+    recordDto.setMetadata(Collections.emptyMap());
 
-    listener.getRecord(record);
+    listener.getRecord(recordDto);
 
-    verify(service).processRecord(record);
+    verify(service).processRecord(recordDto);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
@@ -23,12 +23,12 @@ class SpecialtyEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    Specialty record = new Specialty();
-    AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(record, null, null);
+    Specialty specialty = new Specialty();
+    AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(specialty, null, null);
 
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(record);
+    verify(enricher).enrich(specialty);
     verifyNoMoreInteractions(enricher);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
@@ -44,12 +44,12 @@ class TrustEventListenerTest {
 
   @Test
   void shouldCallEnricherAfterSave() {
-    Trust record = new Trust();
-    AfterSaveEvent<Trust> event = new AfterSaveEvent<>(record, null, null);
+    Trust trust = new Trust();
+    AfterSaveEvent<Trust> event = new AfterSaveEvent<>(trust, null, null);
 
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(record);
+    verify(enricher).enrich(trust);
     verifyNoMoreInteractions(enricher);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
@@ -50,40 +50,40 @@ class ReferenceMapperTest {
 
   @Test
   void shouldMapLabelToLabelWhenLabelPresent() {
-    Record record = new Record();
-    record.setData(Map.of("label", "labelContent", "name", "nameContent"));
+    Record recrd = new Record();
+    recrd.setData(Map.of("label", "labelContent", "name", "nameContent"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected label.", reference.getLabel(), is("labelContent"));
   }
 
   @Test
   void shouldMapNameToLabelWhenLabelNotPresent() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("name", "nameContent"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("name", "nameContent"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected label.", reference.getLabel(), is("nameContent"));
   }
 
   @Test
   void shouldMapPlacementGradeToBooleanWhenTrue() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("placementGrade", "true"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("placementGrade", "true"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected placement grade.", reference.getPlacementGrade(), is(true));
   }
 
   @Test
   void shouldMapPlacementGradeToBooleanWhenFalse() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("placementGrade", "false"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("placementGrade", "false"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected placement grade.", reference.getPlacementGrade(), is(false));
   }
@@ -97,20 +97,20 @@ class ReferenceMapperTest {
 
   @Test
   void shouldMapTrainingGradeToBooleanWhenTrue() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("trainingGrade", "true"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("trainingGrade", "true"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected training grade.", reference.getTrainingGrade(), is(true));
   }
 
   @Test
   void shouldMapTrainingGradeToBooleanWhenFalse() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("trainingGrade", "false"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("trainingGrade", "false"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected training grade.", reference.getTrainingGrade(), is(false));
   }
@@ -124,10 +124,10 @@ class ReferenceMapperTest {
 
   @Test
   void shouldMapCurriculumSubTypeWhenPresent() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("curriculumSubType", "SUB_TYPE_1"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("curriculumSubType", "SUB_TYPE_1"));
 
-    ReferenceDto reference = mapper.toReference(record);
+    ReferenceDto reference = mapper.toReference(recrd);
 
     assertThat("Unexpected curriculum sub type.", reference.getCurriculumSubType(),
         is("SUB_TYPE_1"));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
@@ -48,20 +48,20 @@ class TraineeDetailsMapperTest {
 
   @Test
   void shouldMapCurriculaToEmptySetWhenBadJson() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("curricula", "bad JSON"));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("curricula", "bad JSON"));
 
-    TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(record);
+    TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
     assertThat("Unexpected curricula size.", traineeDetails.getCurricula().size(), is(0));
   }
 
   @Test
   void shouldMapCurriculaToEmptySetWhenMissing() {
-    Record record = new Record();
-    record.setData(Collections.singletonMap("curricula", null));
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("curricula", null));
 
-    TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(record);
+    TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
     assertThat("Unexpected curricula size.", traineeDetails.getCurricula().size(), is(0));
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumSyncServiceTest.java
@@ -62,7 +62,7 @@ class CurriculumSyncServiceTest {
 
   private ReferenceSyncService referenceSyncService;
 
-  private Curriculum record;
+  private Curriculum curriculum;
 
   private Map<String, String> whereMap;
 
@@ -75,8 +75,8 @@ class CurriculumSyncServiceTest {
     referenceSyncService = mock(ReferenceSyncService.class);
     service = new CurriculumSyncService(repository, dataRequestService, referenceSyncService);
 
-    record = new Curriculum();
-    record.setTisId(ID);
+    curriculum = new Curriculum();
+    curriculum.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -84,26 +84,26 @@ class CurriculumSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotCurriculum() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    curriculum.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(curriculum);
 
-    verify(repository).save(record);
+    verify(repository).save(curriculum);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    curriculum.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(curriculum);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -111,11 +111,11 @@ class CurriculumSyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(curriculum));
 
     Optional<Curriculum> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(curriculum));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -150,8 +150,8 @@ class CurriculumSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    curriculum.setOperation(DELETE);
+    service.syncRecord(curriculum);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Curriculum", whereMap);
@@ -195,9 +195,9 @@ class CurriculumSyncServiceTest {
 
   @Test
   void shouldForwardRecordToReferenceSyncService() {
-    record.setOperation(Operation.LOAD);
-    service.syncRecord(record);
+    curriculum.setOperation(Operation.LOAD);
+    service.syncRecord(curriculum);
 
-    verify(referenceSyncService).syncRecord(record);
+    verify(referenceSyncService).syncRecord(curriculum);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PersonCachingTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PersonCachingTest.java
@@ -74,7 +74,7 @@ class PersonCachingTest {
 
   private Cache personCache;
 
-  private Person record;
+  private Person person;
 
   private TcsSyncService service;
 
@@ -93,10 +93,10 @@ class PersonCachingTest {
     restTemplate = mock(RestTemplate.class);
     service = new TcsSyncService(restTemplate, mapper, personService);
 
-    record = new Person();
-    record.setTisId(ID);
-    record.setOperation(Operation.DELETE);
-    record.setTable(Person.ENTITY_NAME);
+    person = new Person();
+    person.setTisId(ID);
+    person.setOperation(Operation.DELETE);
+    person.setTable(Person.ENTITY_NAME);
 
     personCache = cacheManager.getCache(Person.ENTITY_NAME);
   }
@@ -104,16 +104,16 @@ class PersonCachingTest {
   @Test
   void shouldUseCacheForSecondInvocationOfRecord() {
 
-    when(mockPersonRepository.findById(record.getTisId()))
-        .thenReturn(Optional.of(record), Optional.of(new Person()));
-    assertThat(personCache.get(record.getTisId())).isNull();
+    when(mockPersonRepository.findById(person.getTisId()))
+        .thenReturn(Optional.of(person), Optional.of(new Person()));
+    assertThat(personCache.get(person.getTisId())).isNull();
 
-    Optional<Person> actual1 = personService.findById(record.getTisId());
-    assertThat(personCache.get(record.getTisId())).isNotNull();
-    Optional<Person> actual2 = personService.findById(record.getTisId());
+    Optional<Person> actual1 = personService.findById(person.getTisId());
+    assertThat(personCache.get(person.getTisId())).isNotNull();
+    Optional<Person> actual2 = personService.findById(person.getTisId());
 
-    verify(mockPersonRepository).findById(record.getTisId());
-    assertThat(actual1).isPresent().get().isEqualTo(record)
+    verify(mockPersonRepository).findById(person.getTisId());
+    assertThat(actual1).isPresent().get().isEqualTo(person)
         .isEqualTo(actual2.orElseThrow());
   }
 
@@ -129,13 +129,13 @@ class PersonCachingTest {
     service.findById(otherId);
 
     assertThat(personCache.get(otherId)).isNotNull();
-    when(mockPersonRepository.findById(ID)).thenReturn(Optional.of(record));
+    when(mockPersonRepository.findById(ID)).thenReturn(Optional.of(person));
 
     service.findById(ID);
 
     assertThat(personCache.get(ID)).isNotNull();
 
-    service.syncRecord(record);
+    service.syncRecord(person);
 
     assertThat(personCache.get(ID)).isNull();
     assertThat(personCache.get(otherId)).isNotNull();
@@ -145,7 +145,7 @@ class PersonCachingTest {
     service.findById(ID);
     assertThat(personCache.get(ID)).isNotNull();
 
-    verify(mockPersonRepository, times(2)).findById(record.getTisId());
+    verify(mockPersonRepository, times(2)).findById(person.getTisId());
   }
 
   @Test
@@ -172,7 +172,7 @@ class PersonCachingTest {
     updatePerson.setTisId(ID);
     updatePerson.setOperation(Operation.UPDATE);
     updatePerson.setData(data);
-    when(mockPersonRepository.save(updatePerson)).thenReturn(record);
+    when(mockPersonRepository.save(updatePerson)).thenReturn(person);
 
     service.syncRecord(updatePerson);
     assertThat(personCache.get(ID).get()).isEqualTo(updatePerson);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PersonServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PersonServiceTest.java
@@ -43,15 +43,15 @@ class PersonServiceTest {
 
   private static final String ID = "40";
 
-  private Person record;
+  private Person person;
 
   @BeforeEach
   void setUp() {
     personRepository = mock(PersonRepository.class);
     personService = new PersonService(personRepository);
 
-    record = new Person();
-    record.setTisId(ID);
+    person = new Person();
+    person.setTisId(ID);
   }
 
   @Test
@@ -63,11 +63,11 @@ class PersonServiceTest {
 
   @Test
   void shouldFindIfTraineeIsInRepositoryById() {
-    when(personRepository.findById(ID)).thenReturn(Optional.of(record));
+    when(personRepository.findById(ID)).thenReturn(Optional.of(person));
 
     Optional<Person> found = personService.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(person));
 
     verify(personRepository).findById(ID);
     verifyNoMoreInteractions(personRepository);
@@ -75,8 +75,8 @@ class PersonServiceTest {
 
   @Test
   void shouldSavePersonIntoRepositoryWhenPassed() {
-    Person record = new Person();
-    personService.save(record);
-    verify(personRepository).save(record);
+    Person person = new Person();
+    personService.save(person);
+    verify(personRepository).save(person);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PostSyncServiceTest.java
@@ -61,7 +61,7 @@ class PostSyncServiceTest {
 
   private PostRepository repository;
 
-  private Post record;
+  private Post post;
 
   private DataRequestService dataRequestService;
 
@@ -75,8 +75,8 @@ class PostSyncServiceTest {
     repository = mock(PostRepository.class);
     service = new PostSyncService(repository, dataRequestService);
 
-    record = new Post();
-    record.setTisId(ID);
+    post = new Post();
+    post.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -84,26 +84,26 @@ class PostSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotPost() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    post.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(post);
 
-    verify(repository).save(record);
+    verify(repository).save(post);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    post.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(post);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -111,11 +111,11 @@ class PostSyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(post));
 
     Optional<Post> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(post));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -134,13 +134,13 @@ class PostSyncServiceTest {
 
   @Test
   void shouldFindRecordByEmployingBodyIdWhenExists() {
-    when(repository.findByEmployingBodyId(ID)).thenReturn(Collections.singleton(record));
+    when(repository.findByEmployingBodyId(ID)).thenReturn(Collections.singleton(post));
 
     Set<Post> foundRecords = service.findByEmployingBodyId(ID);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     Post foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(post));
 
     verify(repository).findByEmployingBodyId(ID);
     verifyNoMoreInteractions(repository);
@@ -159,13 +159,13 @@ class PostSyncServiceTest {
 
   @Test
   void shouldFindRecordByTrainingBodyIdWhenExists() {
-    when(repository.findByTrainingBodyId(ID)).thenReturn(Collections.singleton(record));
+    when(repository.findByTrainingBodyId(ID)).thenReturn(Collections.singleton(post));
 
     Set<Post> foundRecords = service.findByTrainingBodyId(ID);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     Post foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(post));
 
     verify(repository).findByTrainingBodyId(ID);
     verifyNoMoreInteractions(repository);
@@ -200,8 +200,8 @@ class PostSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    post.setOperation(DELETE);
+    service.syncRecord(post);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Post", whereMap);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncServiceTest.java
@@ -66,11 +66,9 @@ class ProgrammeMembershipSyncServiceTest {
 
   private ProgrammeMembershipRepository repository;
 
-  private ProgrammeMembership record;
+  private ProgrammeMembership programmeMembership;
 
   private DataRequestService dataRequestService;
-
-  private PostSyncService postSyncService;
 
   private Map<String, String> whereMap;
 
@@ -79,12 +77,11 @@ class ProgrammeMembershipSyncServiceTest {
   @BeforeEach
   void setUp() {
     dataRequestService = mock(DataRequestService.class);
-    postSyncService = mock(PostSyncService.class);
     repository = mock(ProgrammeMembershipRepository.class);
     service = new ProgrammeMembershipSyncService(repository, dataRequestService);
 
-    record = new ProgrammeMembership();
-    record.setTisId(ID);
+    programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -92,26 +89,26 @@ class ProgrammeMembershipSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotProgrammeMembership() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    programmeMembership.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(programmeMembership);
 
-    verify(repository).save(record);
+    verify(repository).save(programmeMembership);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    programmeMembership.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(programmeMembership);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -119,13 +116,13 @@ class ProgrammeMembershipSyncServiceTest {
 
   @Test
   void shouldFindRecordByPersonIdWhenExists() {
-    when(repository.findByPersonId(ID)).thenReturn(Collections.singleton(record));
+    when(repository.findByPersonId(ID)).thenReturn(Collections.singleton(programmeMembership));
 
     Set<ProgrammeMembership> foundRecords = service.findByPersonId(ID);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     ProgrammeMembership foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(programmeMembership));
 
     verify(repository).findByPersonId(ID);
     verifyNoMoreInteractions(repository);
@@ -144,13 +141,13 @@ class ProgrammeMembershipSyncServiceTest {
 
   @Test
   void shouldFindRecordByCurriculumIdWhenExists() {
-    when(repository.findByCurriculumId(ID)).thenReturn(Collections.singleton(record));
+    when(repository.findByCurriculumId(ID)).thenReturn(Collections.singleton(programmeMembership));
 
     Set<ProgrammeMembership> foundRecords = service.findByCurriculumId(ID);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     ProgrammeMembership foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(programmeMembership));
 
     verify(repository).findByCurriculumId(ID);
     verifyNoMoreInteractions(repository);
@@ -169,13 +166,13 @@ class ProgrammeMembershipSyncServiceTest {
 
   @Test
   void shouldFindRecordByProgrammeIdWhenExists() {
-    when(repository.findByProgrammeId(ID)).thenReturn(Collections.singleton(record));
+    when(repository.findByProgrammeId(ID)).thenReturn(Collections.singleton(programmeMembership));
 
     Set<ProgrammeMembership> foundRecords = service.findByProgrammeId(ID);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     ProgrammeMembership foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(programmeMembership));
 
     verify(repository).findByProgrammeId(ID);
     verifyNoMoreInteractions(repository);
@@ -197,14 +194,14 @@ class ProgrammeMembershipSyncServiceTest {
 
     when(repository.findBySimilar(personId,
         programmeId, programmeMembershipType, programmeStartDate, programmeEndDate))
-        .thenReturn(Collections.singleton(record));
+        .thenReturn(Collections.singleton(programmeMembership));
 
     Set<ProgrammeMembership> foundRecords = service.findBySimilar(personId,
         programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
     assertThat("Unexpected record count.", foundRecords.size(), is(1));
 
     ProgrammeMembership foundRecord = foundRecords.iterator().next();
-    assertThat("Unexpected record.", foundRecord, sameInstance(record));
+    assertThat("Unexpected record.", foundRecord, sameInstance(programmeMembership));
 
     verify(repository).findBySimilar(personId,
         programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
@@ -244,8 +241,8 @@ class ProgrammeMembershipSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    programmeMembership.setOperation(DELETE);
+    service.syncRecord(programmeMembership);
 
     service.request(ID);
     verify(dataRequestService, times(2))

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeSyncServiceTest.java
@@ -61,7 +61,7 @@ class ProgrammeSyncServiceTest {
 
   private DataRequestService dataRequestService;
 
-  private Programme record;
+  private Programme programme;
 
   private Map<String, String> whereMap;
 
@@ -73,8 +73,8 @@ class ProgrammeSyncServiceTest {
     dataRequestService = mock(DataRequestService.class);
     service = new ProgrammeSyncService(repository, dataRequestService);
 
-    record = new Programme();
-    record.setTisId(ID);
+    programme = new Programme();
+    programme.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -82,26 +82,26 @@ class ProgrammeSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotProgramme() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    programme.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(programme);
 
-    verify(repository).save(record);
+    verify(repository).save(programme);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    programme.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(programme);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -109,11 +109,11 @@ class ProgrammeSyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(programme));
 
     Optional<Programme> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(programme));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -148,8 +148,8 @@ class ProgrammeSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    programme.setOperation(DELETE);
+    service.syncRecord(programme);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Programme", whereMap);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/RecordServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/RecordServiceTest.java
@@ -116,9 +116,9 @@ class RecordServiceTest {
     ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(syncService).syncRecord(recordCaptor.capture());
 
-    Record record = recordCaptor.getValue();
-    assertThat("Unexpected schema.", record.getSchema(), is("testSchema"));
-    assertThat("Unexpected table.", record.getTable(), is("testTable"));
+    Record recrd = recordCaptor.getValue();
+    assertThat("Unexpected schema.", recrd.getSchema(), is("testSchema"));
+    assertThat("Unexpected table.", recrd.getTable(), is("testTable"));
   }
 
   @Test
@@ -141,9 +141,9 @@ class RecordServiceTest {
     ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(syncService).syncRecord(recordCaptor.capture());
 
-    Record record = recordCaptor.getValue();
-    assertThat("Unexpected schema.", record.getSchema(), is("testSchema"));
-    assertThat("Unexpected table.", record.getTable(), is("testTable"));
+    Record recrd = recordCaptor.getValue();
+    assertThat("Unexpected schema.", recrd.getSchema(), is("testSchema"));
+    assertThat("Unexpected table.", recrd.getTable(), is("testTable"));
   }
 
   @Test
@@ -182,9 +182,9 @@ class RecordServiceTest {
     ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(syncService).syncRecord(recordCaptor.capture());
 
-    Record record = recordCaptor.getValue();
-    assertThat("Unexpected record class.", record, instanceOf(Placement.class));
-    assertThat("Unexpected record instance.", record, sameInstance(placement));
+    Record recrd = recordCaptor.getValue();
+    assertThat("Unexpected record class.", recrd, instanceOf(Placement.class));
+    assertThat("Unexpected record instance.", recrd, sameInstance(placement));
     assertThat("Unexpected schema.", placement.getSchema(), is("testSchema"));
     assertThat("Unexpected table.", placement.getTable(), is("testTable"));
   }
@@ -207,8 +207,8 @@ class RecordServiceTest {
     ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
     verify(syncService).syncRecord(recordCaptor.capture());
 
-    Record record = recordCaptor.getValue();
-    assertThat("Unexpected schema.", record.getSchema(), is("testSchema"));
-    assertThat("Unexpected table.", record.getTable(), is("testTable"));
+    Record recrd = recordCaptor.getValue();
+    assertThat("Unexpected schema.", recrd.getSchema(), is("testSchema"));
+    assertThat("Unexpected table.", recrd.getTable(), is("testTable"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
@@ -57,7 +57,7 @@ class ReferenceSyncServiceTest {
 
   private RestTemplate restTemplate;
 
-  private Record record;
+  private Record recrd;
 
   @BeforeEach
   void setUp() {
@@ -69,15 +69,15 @@ class ReferenceSyncServiceTest {
     restTemplate = mock(RestTemplate.class);
     service = new ReferenceSyncService(restTemplate, mapper);
 
-    record = new Record();
-    record.setTisId("idValue");
+    recrd = new Record();
+    recrd.setTisId("idValue");
   }
 
   @Test
   void shouldNotSyncRecordWhenTableNotSupported() {
-    record.setTable("unsupportedTable");
+    recrd.setTable("unsupportedTable");
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verifyNoInteractions(restTemplate);
   }
@@ -86,16 +86,16 @@ class ReferenceSyncServiceTest {
   @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office"})
   void shouldInsertRecordWhenOperationIsLoad(String tableName, String apiName) {
-    record.setTable(tableName);
-    record.setOperation(Operation.LOAD);
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.LOAD);
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
         "label", "labelValue",
         "status", "CURRENT");
-    record.setData(data);
+    recrd.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     ReferenceDto expectedDto = new ReferenceDto();
     expectedDto.setTisId("idValue");
@@ -111,16 +111,16 @@ class ReferenceSyncServiceTest {
   @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office"})
   void shouldInsertRecordWhenOperationIsInsert(String tableName, String apiName) {
-    record.setTable(tableName);
-    record.setOperation(Operation.INSERT);
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.INSERT);
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
         "label", "labelValue",
         "status", "CURRENT");
-    record.setData(data);
+    recrd.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     ReferenceDto expectedDto = new ReferenceDto();
     expectedDto.setTisId("idValue");
@@ -136,16 +136,16 @@ class ReferenceSyncServiceTest {
   @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office"})
   void shouldUpdateRecordWhenOperationIsUpdate(String tableName, String apiName) {
-    record.setTable(tableName);
-    record.setOperation(Operation.UPDATE);
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.UPDATE);
 
     Map<String, String> data = Map.of(
         "abbreviation", "abbreviationValue",
         "label", "labelValue",
         "status", "CURRENT");
-    record.setData(data);
+    recrd.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     ReferenceDto expectedDto = new ReferenceDto();
     expectedDto.setTisId("idValue");
@@ -161,11 +161,11 @@ class ReferenceSyncServiceTest {
   @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office"})
   void shouldDeleteRecordWhenOperationIsDelete(String tableName, String apiName) {
-    record.setTisId("40");
-    record.setTable(tableName);
-    record.setOperation(Operation.DELETE);
+    recrd.setTisId("40");
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(restTemplate).delete(anyString(), eq(apiName), eq("40"));
     verifyNoMoreInteractions(restTemplate);
@@ -174,12 +174,12 @@ class ReferenceSyncServiceTest {
   @ParameterizedTest(name = "Should delete record when operation is {0} and status is INACTIVE")
   @EnumSource(Operation.class)
   void shouldDeleteRecordWhenStatusIsInactive(Operation operation) {
-    record.setTisId("40");
-    record.setTable("Grade");
-    record.setOperation(operation);
-    record.setData(Collections.singletonMap("status", "INACTIVE"));
+    recrd.setTisId("40");
+    recrd.setTable("Grade");
+    recrd.setOperation(operation);
+    recrd.setData(Collections.singletonMap("status", "INACTIVE"));
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(restTemplate).delete(anyString(), eq("grade"), eq("40"));
     verifyNoMoreInteractions(restTemplate);
@@ -188,12 +188,12 @@ class ReferenceSyncServiceTest {
   @ParameterizedTest(name = "Should delete record when operation is {0} and status is DELETE")
   @EnumSource(Operation.class)
   void shouldDeleteRecordWhenStatusIsDelete(Operation operation) {
-    record.setTisId("40");
-    record.setTable("Grade");
-    record.setOperation(operation);
-    record.setData(Collections.singletonMap("status", "DELETE"));
+    recrd.setTisId("40");
+    recrd.setTable("Grade");
+    recrd.setOperation(operation);
+    recrd.setData(Collections.singletonMap("status", "DELETE"));
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(restTemplate).delete(anyString(), eq("grade"), eq("40"));
     verifyNoMoreInteractions(restTemplate);
@@ -201,30 +201,30 @@ class ReferenceSyncServiceTest {
 
   @Test
   void shouldNotThrowWhenValidationFails() {
-    record.setTisId("40");
-    record.setTable("Grade");
-    record.setOperation(Operation.LOAD);
+    recrd.setTisId("40");
+    recrd.setTable("Grade");
+    recrd.setOperation(Operation.LOAD);
 
     HttpClientErrorException exception = new HttpClientErrorException(
         HttpStatus.UNPROCESSABLE_ENTITY);
     when(restTemplate.postForLocation(anyString(), any(ReferenceDto.class), anyString()))
         .thenThrow(exception);
 
-    assertDoesNotThrow(() -> service.syncRecord(record));
+    assertDoesNotThrow(() -> service.syncRecord(recrd));
   }
 
   @Test
   void shouldThrowWhenNonValidationFailure() {
-    record.setTisId("40");
-    record.setTable("Grade");
-    record.setOperation(Operation.LOAD);
-    record.setData(Collections.singletonMap("status", "CURRENT"));
+    recrd.setTisId("40");
+    recrd.setTable("Grade");
+    recrd.setOperation(Operation.LOAD);
+    recrd.setData(Collections.singletonMap("status", "CURRENT"));
 
     HttpClientErrorException exception = new HttpClientErrorException(
         HttpStatus.UNSUPPORTED_MEDIA_TYPE);
     when(restTemplate.postForLocation(anyString(), any(ReferenceDto.class), anyString()))
         .thenThrow(exception);
 
-    assertThrows(HttpClientErrorException.class, () -> service.syncRecord(record));
+    assertThrows(HttpClientErrorException.class, () -> service.syncRecord(recrd));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/SiteSyncServiceTest.java
@@ -61,7 +61,7 @@ class SiteSyncServiceTest {
 
   private DataRequestService dataRequestService;
 
-  private Site record;
+  private Site site;
 
   private Map<String, String> whereMap;
 
@@ -73,8 +73,8 @@ class SiteSyncServiceTest {
     dataRequestService = mock(DataRequestService.class);
     service = new SiteSyncService(repository, dataRequestService);
 
-    record = new Site();
-    record.setTisId(ID);
+    site = new Site();
+    site.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -82,26 +82,26 @@ class SiteSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotSite() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    site.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(site);
 
-    verify(repository).save(record);
+    verify(repository).save(site);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    site.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(site);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -109,11 +109,11 @@ class SiteSyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(site));
 
     Optional<Site> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(site));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -148,8 +148,8 @@ class SiteSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    site.setOperation(DELETE);
+    service.syncRecord(site);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Site", whereMap);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncServiceTest.java
@@ -40,7 +40,7 @@ class SpecialtySyncServiceTest {
 
   private DataRequestService dataRequestService;
 
-  private Specialty record;
+  private Specialty specialty;
 
   private Map<String, String> whereMap;
 
@@ -52,8 +52,8 @@ class SpecialtySyncServiceTest {
     dataRequestService = mock(DataRequestService.class);
     service = new SpecialtySyncService(repository, dataRequestService);
 
-    record = new Specialty();
-    record.setTisId(ID);
+    specialty = new Specialty();
+    specialty.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -61,26 +61,26 @@ class SpecialtySyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotSpecialty() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    specialty.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(specialty);
 
-    verify(repository).save(record);
+    verify(repository).save(specialty);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    specialty.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(specialty);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -88,11 +88,11 @@ class SpecialtySyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(specialty));
 
     Optional<Specialty> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(specialty));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -127,8 +127,8 @@ class SpecialtySyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    specialty.setOperation(DELETE);
+    service.syncRecord(specialty);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Specialty", whereMap);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -71,7 +71,7 @@ class TcsSyncServiceTest {
 
   private Map<String, String> data;
 
-  private Record record;
+  private Record recrd;
 
   @BeforeEach
   void setUp() {
@@ -104,35 +104,35 @@ class TcsSyncServiceTest {
     data.put("personId", "personIdValue");
     data.put("role", REQUIRED_ROLE);
 
-    record = new Record();
-    record.setTisId("idValue");
+    recrd = new Record();
+    recrd.setTisId("idValue");
   }
 
   @Test
   void shouldNotSyncRecordWhenTableNotSupported() {
-    record.setTable("unsupportedTable");
+    recrd.setTable("unsupportedTable");
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verifyNoInteractions(restTemplate);
   }
 
   @Test
   void shouldSaveRecordIntoPersonRepositoryIfRecordIsAPersonAndNotInPersonRepository() {
-    Person record = new Person();
-    record.setTisId("idValue");
-    record.setTable("Person");
-    record.setOperation(INSERT);
+    Person person = new Person();
+    person.setTisId("idValue");
+    person.setTable("Person");
+    person.setOperation(INSERT);
     data.put("role", REQUIRED_ROLE);
-    record.setData(data);
+    person.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(person);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
     expectedDto.setPublicHealthNumber("publicHealthNumberValue");
 
-    verify(personService).save(record);
+    verify(personService).save(person);
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("basic-details"),
             eq("idValue"));
@@ -143,13 +143,13 @@ class TcsSyncServiceTest {
   @ValueSource(strings = {"nonRequiredRole", "prefix-" + REQUIRED_ROLE, REQUIRED_ROLE + "-suffix",
       "prefix-" + REQUIRED_ROLE + "-suffix"})
   void shouldNotPatchBasicDetailsWhenRequiredRoleNotFound(String role) {
-    Person record = new Person();
-    record.setTisId("idValue");
-    record.setTable("Person");
-    record.setOperation(INSERT);
-    record.setData(Collections.singletonMap("role", role));
+    Person person = new Person();
+    person.setTisId("idValue");
+    person.setTable("Person");
+    person.setOperation(INSERT);
+    person.setData(Collections.singletonMap("role", role));
 
-    service.syncRecord(record);
+    service.syncRecord(person);
 
     verifyNoInteractions(restTemplate);
     verify(personService, times(1)).findById(anyString());
@@ -160,14 +160,14 @@ class TcsSyncServiceTest {
   @ValueSource(strings = {"Dr in Training", "roleBefore," + REQUIRED_ROLE, REQUIRED_ROLE,
       REQUIRED_ROLE + ",roleAfter", "roleBefore," + REQUIRED_ROLE + ",roleAfter"})
   void shouldPatchBasicDetailsWhenRequiredRoleFound(String role) {
-    Person record = new Person();
-    record.setTisId("idValue");
-    record.setTable("Person");
-    record.setOperation(INSERT);
+    Person person = new Person();
+    person.setTisId("idValue");
+    person.setTable("Person");
+    person.setOperation(INSERT);
     data.put("role", role);
-    record.setData(data);
+    person.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(person);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -183,18 +183,16 @@ class TcsSyncServiceTest {
       "Should patch basic details when operation is {0}, role is valid and table is Person")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldPatchBasicDetailsWhenValidOperations(Operation operation) {
-    Person record = new Person();
-    record.setTisId("idValue");
-    record.setTable("Person");
-    record.setOperation(operation);
+    Person person = new Person();
+    person.setTisId("idValue");
+    person.setTable("Person");
+    person.setOperation(operation);
     data.put("role", REQUIRED_ROLE);
-    record.setData(data);
+    person.setData(data);
 
-    Optional<Person> person = Optional.of(new Person());
+    when(personService.findById("idValue")).thenReturn(Optional.of(new Person()));
 
-    when(personService.findById("idValue")).thenReturn(person);
-
-    service.syncRecord(record);
+    service.syncRecord(person);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -210,15 +208,15 @@ class TcsSyncServiceTest {
       name = "Should patch contact details when operation is {0} and table is ContactDetails")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldPatchContactDetails(Operation operation) {
-    record.setTable("ContactDetails");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("ContactDetails");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById("idValue")).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -250,15 +248,15 @@ class TcsSyncServiceTest {
     data.put("gdcNumber", "gdcNumberValue");
     data.put("gdcStatus", "gdcStatusValue");
 
-    record.setTable("GdcDetails");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("GdcDetails");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById("idValue")).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -279,15 +277,15 @@ class TcsSyncServiceTest {
     data.put("gmcNumber", "gmcNumberValue");
     data.put("gmcStatus", "gmcStatusValue");
 
-    record.setTable("GmcDetails");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("GmcDetails");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById("idValue")).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -307,15 +305,15 @@ class TcsSyncServiceTest {
     Map<String, String> data = new HashMap<>();
     data.put("owner", "personOwnerValue");
 
-    record.setTable("PersonOwner");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("PersonOwner");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById("idValue")).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -335,14 +333,14 @@ class TcsSyncServiceTest {
     data.put("dateOfBirth", "1978-03-23");
     data.put("gender", "genderValue");
 
-    record.setTable("PersonalDetails");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("PersonalDetails");
+    recrd.setOperation(operation);
+    recrd.setData(data);
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById("idValue")).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTraineeTisId("idValue");
@@ -367,15 +365,15 @@ class TcsSyncServiceTest {
         "qualificationAttainedDate", now.toString(),
         "medicalSchool", "medicalSchoolValue");
 
-    record.setTable("Qualification");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("Qualification");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById(anyString())).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
     expectedDto.setTisId("idValue");
@@ -398,15 +396,15 @@ class TcsSyncServiceTest {
     Map<String, String> data = Map.of(
         "personId", "personIdValue");
 
-    record.setTable("ProgrammeMembership");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("ProgrammeMembership");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById(anyString())).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(restTemplate)
         .delete(anyString(), eq("programme-membership"),
@@ -420,15 +418,15 @@ class TcsSyncServiceTest {
     Map<String, String> data = Map.of(
         "traineeId", "traineeIdValue");
 
-    record.setTable("Placement");
-    record.setOperation(operation);
-    record.setData(data);
+    recrd.setTable("Placement");
+    recrd.setOperation(operation);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById(anyString())).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(restTemplate)
         .delete(anyString(), eq("placement"), eq("traineeIdValue"), eq("idValue"));
@@ -443,15 +441,15 @@ class TcsSyncServiceTest {
         "personId", "personIdValue",
         "traineeId", "traineeIdValue");
 
-    record.setTable(tableName);
-    record.setOperation(DELETE);
-    record.setData(data);
+    recrd.setTable(tableName);
+    recrd.setOperation(DELETE);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
     when(personService.findById(anyString())).thenReturn(person);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verifyNoInteractions(restTemplate);
   }
@@ -461,11 +459,11 @@ class TcsSyncServiceTest {
   @ValueSource(strings = {"ContactDetails", "GdcDetails", "GmcDetails", "Person", "PersonOwner",
       "PersonalDetails", "Qualification"})
   void shouldOnlyUpdateIfTheTraineeIsInTheRepository(String tableName) {
-    record.setTable(tableName);
-    record.setOperation(UPDATE);
-    record.setData(data);
+    recrd.setTable(tableName);
+    recrd.setOperation(UPDATE);
+    recrd.setData(data);
 
-    service.syncRecord(record);
+    service.syncRecord(recrd);
 
     verify(personService).findById(or(eq("idValue"), eq("personIdValue")));
     verifyNoInteractions(restTemplate);
@@ -476,9 +474,9 @@ class TcsSyncServiceTest {
   @ValueSource(strings = {"ContactDetails", "GdcDetails", "GmcDetails", "Person", "PersonOwner",
       "PersonalDetails", "Qualification"})
   void shouldThrowErrorWhenNon404ErrorForDetails(String tableName) {
-    record.setTable(tableName);
-    record.setOperation(UPDATE);
-    record.setData(data);
+    recrd.setTable(tableName);
+    recrd.setOperation(UPDATE);
+    recrd.setData(data);
 
     Optional<Person> person = Optional.of(new Person());
 
@@ -489,6 +487,6 @@ class TcsSyncServiceTest {
         restTemplate.patchForObject(anyString(), any(), eq(Object.class), anyString(), anyString()))
         .thenThrow(new HttpClientErrorException(HttpStatus.METHOD_NOT_ALLOWED));
 
-    assertThrows(RestClientException.class, () -> service.syncRecord(record));
+    assertThrows(RestClientException.class, () -> service.syncRecord(recrd));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TrustSyncServiceTest.java
@@ -58,7 +58,7 @@ class TrustSyncServiceTest {
 
   private TrustRepository repository;
 
-  private Trust record;
+  private Trust trust;
 
   private DataRequestService dataRequestService;
 
@@ -72,8 +72,8 @@ class TrustSyncServiceTest {
     dataRequestService = mock(DataRequestService.class);
     service = new TrustSyncService(repository, dataRequestService);
 
-    record = new Trust();
-    record.setTisId(ID);
+    trust = new Trust();
+    trust.setTisId(ID);
 
     whereMap = Map.of("id", ID);
     whereMap2 = Map.of("id", ID_2);
@@ -81,26 +81,26 @@ class TrustSyncServiceTest {
 
   @Test
   void shouldThrowExceptionIfRecordNotTrust() {
-    Record record = new Record();
-    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(record));
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldStoreRecords(Operation operation) {
-    record.setOperation(operation);
+    trust.setOperation(operation);
 
-    service.syncRecord(record);
+    service.syncRecord(trust);
 
-    verify(repository).save(record);
+    verify(repository).save(trust);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldDeleteRecordFromStore() {
-    record.setOperation(DELETE);
+    trust.setOperation(DELETE);
 
-    service.syncRecord(record);
+    service.syncRecord(trust);
 
     verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
@@ -108,11 +108,11 @@ class TrustSyncServiceTest {
 
   @Test
   void shouldFindRecordByIdWhenExists() {
-    when(repository.findById(ID)).thenReturn(Optional.of(record));
+    when(repository.findById(ID)).thenReturn(Optional.of(trust));
 
     Optional<Trust> found = service.findById(ID);
     assertThat("Record not found.", found.isPresent(), is(true));
-    assertThat("Unexpected record.", found.orElse(null), sameInstance(record));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(trust));
 
     verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
@@ -147,8 +147,8 @@ class TrustSyncServiceTest {
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     service.request(ID);
 
-    record.setOperation(DELETE);
-    service.syncRecord(record);
+    trust.setOperation(DELETE);
+    service.syncRecord(trust);
 
     service.request(ID);
     verify(dataRequestService, times(2)).sendRequest("Trust", whereMap);


### PR DESCRIPTION
`record` is a restricted identifier in Java and should not be used as a
variable name.

NO-TICKET