### PR TITLE
feat: Add Post record queue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.18.3"
+version = "0.19.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostListener.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import uk.nhs.hee.tis.trainee.sync.model.Post;
+import uk.nhs.hee.tis.trainee.sync.service.PostSyncService;
+
+@Slf4j
+@Component
+@Validated
+public class PostListener {
+
+  private final PostSyncService postService;
+
+  PostListener(PostSyncService postService) {
+    this.postService = postService;
+  }
+
+  @Validated
+  @SqsListener(value = "${application.aws.sqs.post}", deletionPolicy = ON_SUCCESS)
+  void getPost(@Valid Post post) {
+    log.debug("Received post {}.", post);
+    postService.syncPost(post);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ application:
   aws:
     sqs:
       placement: ${PLACEMENT_QUEUE_URL:}
+      post: ${POST_QUEUE_URL:}
       record: ${RECORD_QUEUE_URL:}
       request: ${REQUEST_QUEUE_URL:}
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostListenerTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Collections;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.Post;
+import uk.nhs.hee.tis.trainee.sync.service.PostSyncService;
+
+class PostListenerTest {
+
+  private PostListener listener;
+
+  private PostSyncService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(PostSyncService.class);
+    listener = new PostListener(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenDataNull() {
+    Post post = new Post();
+    post.setMetadata(Collections.emptyMap());
+
+    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
+
+    verifyNoInteractions(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenMetadataNull() {
+    Post post = new Post();
+    post.setData(Collections.emptyMap());
+
+    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
+
+    verifyNoInteractions(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenDataAndMetadataNull() {
+    Post post = new Post();
+
+    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldProcessRecordWhenDataAndMetadataNotNull() {
+    Post post = new Post();
+    post.setData(Collections.emptyMap());
+    post.setMetadata(Collections.emptyMap());
+
+    listener.getPost(post);
+
+    verify(service).syncPost(post);
+  }
+}


### PR DESCRIPTION
Add a queue for post records, a listener should read from the post queue
and perform the post sync for each record.

When a post is received on the record queue, the post should be
re-queued in the post queue.

TIS21-1691