### PR TITLE
feat: Add type and internal fields to DBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.19.1"
+version = "0.20.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/ReferenceDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/ReferenceDto.java
@@ -37,4 +37,8 @@ public class ReferenceDto {
 
   // Curriculum fields.
   private String curriculumSubType;
+
+  // DBC fields.
+  private String type;
+  private Boolean internal;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapper.java
@@ -27,10 +27,12 @@ import uk.nhs.hee.tis.trainee.sync.dto.ReferenceDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.Abbreviation;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.CurriculumSubType;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.Internal;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.Label;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.PlacementGrade;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.Status;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.TrainingGrade;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.ReferenceUtil.Type;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 
 @Mapper(componentModel = "spring", uses = ReferenceUtil.class)
@@ -42,5 +44,7 @@ public interface ReferenceMapper {
   @Mapping(target = "placementGrade", source = "data", qualifiedBy = PlacementGrade.class)
   @Mapping(target = "trainingGrade", source = "data", qualifiedBy = TrainingGrade.class)
   @Mapping(target = "curriculumSubType", source = "data", qualifiedBy = CurriculumSubType.class)
+  @Mapping(target = "type", source = "data", qualifiedBy = Type.class)
+  @Mapping(target = "internal", source = "data", qualifiedBy = Internal.class)
   ReferenceDto toReference(Record recrd);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
@@ -42,6 +42,13 @@ public class ReferenceUtil {
   @Qualifier
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.SOURCE)
+  public @interface Internal {
+
+  }
+
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
   public @interface Label {
 
   }
@@ -70,6 +77,13 @@ public class ReferenceUtil {
   @Qualifier
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.SOURCE)
+  public @interface Type {
+
+  }
+
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
   public @interface CurriculumSubType {
 
   }
@@ -77,6 +91,12 @@ public class ReferenceUtil {
   @Abbreviation
   public String abbreviation(Map<String, String> data) {
     return data.get("abbreviation");
+  }
+
+  @Internal
+  public Boolean internal(Map<String, String> data) {
+    String internal = data.get("internal");
+    return internal == null ? null : Boolean.parseBoolean(internal);
   }
 
   @Label
@@ -104,6 +124,11 @@ public class ReferenceUtil {
   public Boolean trainingGrade(Map<String, String> data) {
     String trainingGrade = data.get("trainingGrade");
     return trainingGrade == null ? null : Boolean.parseBoolean(trainingGrade);
+  }
+
+  @Type
+  public String type(Map<String, String> data) {
+    return data.get("type");
   }
 
   @CurriculumSubType

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
@@ -49,6 +49,33 @@ class ReferenceMapperTest {
   }
 
   @Test
+  void shouldMapInternalToBooleanWhenTrue() {
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("internal", "true"));
+
+    ReferenceDto reference = mapper.toReference(recrd);
+
+    assertThat("Unexpected internal flag.", reference.getInternal(), is(true));
+  }
+
+  @Test
+  void shouldMapInternalToBooleanWhenFalse() {
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("internal", "false"));
+
+    ReferenceDto reference = mapper.toReference(recrd);
+
+    assertThat("Unexpected internal flag.", reference.getInternal(), is(false));
+  }
+
+  @Test
+  void shouldMapInternalToNullWhenNotPresent() {
+    ReferenceDto reference = mapper.toReference(new Record());
+
+    assertThat("Unexpected internal flag.", reference.getInternal(), nullValue());
+  }
+
+  @Test
   void shouldMapLabelToLabelWhenLabelPresent() {
     Record recrd = new Record();
     recrd.setData(Map.of("label", "labelContent", "name", "nameContent"));
@@ -120,6 +147,23 @@ class ReferenceMapperTest {
     ReferenceDto reference = mapper.toReference(new Record());
 
     assertThat("Unexpected training grade.", reference.getTrainingGrade(), nullValue());
+  }
+
+  @Test
+  void shouldMapTypeWhenPresent() {
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("type", "TYPE_1"));
+
+    ReferenceDto reference = mapper.toReference(recrd);
+
+    assertThat("Unexpected type.", reference.getType(), is("TYPE_1"));
+  }
+
+  @Test
+  void shouldMapTypeToNullWhenNotPresent() {
+    ReferenceDto reference = mapper.toReference(new Record());
+
+    assertThat("Unexpected type.", reference.getType(), nullValue());
   }
 
   @Test


### PR DESCRIPTION
The DBC has had `type` and `internal` fields added to allow better
identification of the scope/context of each DBC.

TIS21-1659