### PR TITLE
fix: Boolean values not handled correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.20.0"
+version = "0.20.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/ReferenceUtil.java
@@ -96,7 +96,7 @@ public class ReferenceUtil {
   @Internal
   public Boolean internal(Map<String, String> data) {
     String internal = data.get("internal");
-    return internal == null ? null : Boolean.parseBoolean(internal);
+    return internal == null ? null : internal.equals("1");
   }
 
   @Label
@@ -117,13 +117,13 @@ public class ReferenceUtil {
   @PlacementGrade
   public Boolean placementGrade(Map<String, String> data) {
     String placementGrade = data.get("placementGrade");
-    return placementGrade == null ? null : Boolean.parseBoolean(placementGrade);
+    return placementGrade == null ? null : placementGrade.equals("1");
   }
 
   @TrainingGrade
   public Boolean trainingGrade(Map<String, String> data) {
     String trainingGrade = data.get("trainingGrade");
-    return trainingGrade == null ? null : Boolean.parseBoolean(trainingGrade);
+    return trainingGrade == null ? null : trainingGrade.equals("1");
   }
 
   @Type

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ReferenceMapperTest.java
@@ -51,7 +51,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapInternalToBooleanWhenTrue() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("internal", "true"));
+    recrd.setData(Collections.singletonMap("internal", "1"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 
@@ -61,7 +61,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapInternalToBooleanWhenFalse() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("internal", "false"));
+    recrd.setData(Collections.singletonMap("internal", "0"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 
@@ -98,7 +98,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapPlacementGradeToBooleanWhenTrue() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("placementGrade", "true"));
+    recrd.setData(Collections.singletonMap("placementGrade", "1"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 
@@ -108,7 +108,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapPlacementGradeToBooleanWhenFalse() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("placementGrade", "false"));
+    recrd.setData(Collections.singletonMap("placementGrade", "0"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 
@@ -125,7 +125,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapTrainingGradeToBooleanWhenTrue() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("trainingGrade", "true"));
+    recrd.setData(Collections.singletonMap("trainingGrade", "1"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 
@@ -135,7 +135,7 @@ class ReferenceMapperTest {
   @Test
   void shouldMapTrainingGradeToBooleanWhenFalse() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("trainingGrade", "false"));
+    recrd.setData(Collections.singletonMap("trainingGrade", "0"));
 
     ReferenceDto reference = mapper.toReference(recrd);
 


### PR DESCRIPTION
Boolean values were expected to be `"true"` and `"false"` but are
actually `"1"` and `"0"` respectively.
Update ReferenceUtil to correctly map the boolean values.

TIS21-1659