### PR TITLE
feat: Process PlacementSpecialty via queue

### DIFF
--- a/.aws/task-definition-pre-prod.json
+++ b/.aws/task-definition-pre-prod.json
@@ -72,6 +72,10 @@
           "valueFrom": "/tis/trainee/sync/preprod/queue-url/placement"
         },
         {
+          "name": "PLACEMENT_SPECIALTY_QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/preprod/queue-url/placement-specialty"
+        },
+        {
           "name": "POST_QUEUE_URL",
           "valueFrom": "/tis/trainee/sync/preprod/queue-url/post"
         },

--- a/.aws/task-definition-prod.json
+++ b/.aws/task-definition-prod.json
@@ -72,6 +72,10 @@
           "valueFrom": "/tis/trainee/sync/prod/queue-url/placement"
         },
         {
+          "name": "PLACEMENT_SPECIALTY_QUEUE_URL",
+          "valueFrom": "/tis/trainee/sync/prod/queue-url/placement-specialty"
+        },
+        {
           "name": "POST_QUEUE_URL",
           "valueFrom": "/tis/trainee/sync/prod/queue-url/post"
         },

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.20.2"
+version = "0.21.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementListener.java
@@ -24,16 +24,13 @@ package uk.nhs.hee.tis.trainee.sync.event;
 import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
 
 import io.awspring.cloud.messaging.listener.annotation.SqsListener;
-import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.annotation.Validated;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
 
 @Slf4j
 @Component
-@Validated
 public class PlacementListener {
 
   private final PlacementSyncService placementService;
@@ -42,9 +39,8 @@ public class PlacementListener {
     this.placementService = placementService;
   }
 
-  @Validated
   @SqsListener(value = "${application.aws.sqs.placement}", deletionPolicy = ON_SUCCESS)
-  void getPlacement(@Valid Placement placement) {
+  void getPlacement(Placement placement) {
     log.debug("Received placement {}.", placement);
     placementService.syncPlacement(placement);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
@@ -1,23 +1,40 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
 
 @Slf4j
 @Component
 public class PlacementSpecialtyEventListener extends
     AbstractMongoEventListener<PlacementSpecialty> {
 
+  private final PlacementSyncService placementService;
+
   private final PlacementEnricherFacade placementEnricher;
 
-  PlacementSpecialtyEventListener(PlacementEnricherFacade placementEnricher) {
+  private final QueueMessagingTemplate messagingTemplate;
+
+  private final String placementQueueUrl;
+
+  PlacementSpecialtyEventListener(PlacementEnricherFacade placementEnricher,
+      PlacementSyncService placementService,
+      QueueMessagingTemplate messagingTemplate,
+      @Value("${application.aws.sqs.placement}") String placementQueueUrl) {
     this.placementEnricher = placementEnricher;
+    this.placementService = placementService;
+    this.messagingTemplate = messagingTemplate;
+    this.placementQueueUrl = placementQueueUrl;
   }
 
   @Override
@@ -25,7 +42,17 @@ public class PlacementSpecialtyEventListener extends
     super.onAfterSave(event);
 
     PlacementSpecialty placementSpecialty = event.getSource();
-    placementEnricher.enrich(placementSpecialty);
+    String placementId = placementSpecialty.getData().get("placementId");
+
+    if (placementId != null) {
+      Optional<Placement> placement = placementService.findById(placementId);
+
+      if (placement.isPresent()) {
+        messagingTemplate.convertAndSend(placementQueueUrl, placement.get());
+      } else {
+        placementService.request(placementId);
+      }
+    }
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
@@ -45,10 +46,13 @@ public class PlacementSpecialtyEventListener extends
     String placementId = placementSpecialty.getData().get("placementId");
 
     if (placementId != null) {
-      Optional<Placement> placement = placementService.findById(placementId);
+      Optional<Placement> optionalPlacement = placementService.findById(placementId);
 
-      if (placement.isPresent()) {
-        messagingTemplate.convertAndSend(placementQueueUrl, placement.get());
+      if (optionalPlacement.isPresent()) {
+        // Default the placement to LOAD.
+        Placement placement = optionalPlacement.get();
+        placement.setOperation(Operation.LOAD);
+        messagingTemplate.convertAndSend(placementQueueUrl, placement);
       } else {
         placementService.request(placementId);
       }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListener.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
+
+@Slf4j
+@Component
+@Validated
+public class PlacementSpecialtyListener {
+
+  private final PlacementSpecialtySyncService placementSpecialtyService;
+
+  PlacementSpecialtyListener(PlacementSpecialtySyncService placementSpecialtyService) {
+    this.placementSpecialtyService = placementSpecialtyService;
+  }
+
+  @Validated
+  @SqsListener(value = "${application.aws.sqs.placement-specialty}", deletionPolicy = ON_SUCCESS)
+  void getPlacementSpecialty(@Valid PlacementSpecialty placementSpecialty) {
+    log.debug("Received placement specialty {}.", placementSpecialty);
+    placementSpecialtyService.syncPlacementSpecialty(placementSpecialty);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListener.java
@@ -24,16 +24,13 @@ package uk.nhs.hee.tis.trainee.sync.event;
 import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
 
 import io.awspring.cloud.messaging.listener.annotation.SqsListener;
-import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.annotation.Validated;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
 
 @Slf4j
 @Component
-@Validated
 public class PlacementSpecialtyListener {
 
   private final PlacementSpecialtySyncService placementSpecialtyService;
@@ -42,9 +39,8 @@ public class PlacementSpecialtyListener {
     this.placementSpecialtyService = placementSpecialtyService;
   }
 
-  @Validated
   @SqsListener(value = "${application.aws.sqs.placement-specialty}", deletionPolicy = ON_SUCCESS)
-  void getPlacementSpecialty(@Valid PlacementSpecialty placementSpecialty) {
+  void getPlacementSpecialty(PlacementSpecialty placementSpecialty) {
     log.debug("Received placement specialty {}.", placementSpecialty);
     placementSpecialtyService.syncPlacementSpecialty(placementSpecialty);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostListener.java
@@ -24,16 +24,13 @@ package uk.nhs.hee.tis.trainee.sync.event;
 import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
 
 import io.awspring.cloud.messaging.listener.annotation.SqsListener;
-import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.validation.annotation.Validated;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.service.PostSyncService;
 
 @Slf4j
 @Component
-@Validated
 public class PostListener {
 
   private final PostSyncService postService;
@@ -42,9 +39,8 @@ public class PostListener {
     this.postService = postService;
   }
 
-  @Validated
   @SqsListener(value = "${application.aws.sqs.post}", deletionPolicy = ON_SUCCESS)
-  void getPost(@Valid Post post) {
+  void getPost(Post post) {
     log.debug("Received post {}.", post);
     postService.syncPost(post);
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -212,47 +212,6 @@ public class PlacementEnricherFacade {
   }
 
   /**
-   * Sync an enriched placement with the associated placement specialty as the starting point.
-   *
-   * @param placementSpecialty The placement specialty triggering placement enrichment.
-   */
-  public void enrich(PlacementSpecialty placementSpecialty) {
-    enrich(placementSpecialty, null, null);
-  }
-
-  /**
-   * Enrich the placement associated with the placementSpecialty with the given placement and
-   * specialty ids, if these are null they will be queried for.
-   *
-   * @param placementSpecialty The placementSpecialty to get associated placement from.
-   * @param placementId        The placement enrich with.
-   * @param specialtyId        The specialty to enrich with.
-   */
-  private void enrich(PlacementSpecialty placementSpecialty, @Nullable String placementId,
-      @Nullable String specialtyId) {
-
-    if (placementId == null) {
-      placementId = getPlacementIdFromPlacementSpecialty(placementSpecialty);
-    }
-
-    if (specialtyId == null) {
-      specialtyId = getSpecialtyId(placementSpecialty);
-    }
-
-    Optional<Placement> placement = getPlacement(placementId);
-    Optional<Specialty> specialty = getSpecialty(specialtyId);
-
-    boolean doEnrich = placement.isPresent() && specialty.isPresent();
-
-    if (doEnrich) {
-      Placement finalPlacement = placement.get();
-      Specialty finalSpecialty = specialty.get();
-      populateSpecialtyDetails(finalPlacement, getSpecialtyName(finalSpecialty));
-      enrich(finalPlacement, true, true, false);
-    }
-  }
-
-  /**
    * Enrich placements associated with the Specialty with the given specialty name, if this is null
    * it will be queried for.
    *
@@ -440,26 +399,6 @@ public class PlacementEnricherFacade {
     return trust.getData().get(TRUST_NAME);
   }
 
-  /**
-   * Get the placement for the given id, if the placement is not found it will be requested.
-   *
-   * @param placementId The id of the placement to get.
-   * @return The placement, or Optional.empty() if the ID is null or the placement is not found.
-   */
-  private Optional<Placement> getPlacement(@Nullable String placementId) {
-    if (placementId == null) {
-      return Optional.empty();
-    }
-
-    Optional<Placement> optionalPlacement = placementService.findById(placementId);
-
-    if (optionalPlacement.isEmpty()) {
-      placementService.request(placementId);
-    }
-
-    return optionalPlacement;
-  }
-
   private boolean isPlacementSpecialtyExists(String placementId) {
     if (placementId != null) {
       Optional<PlacementSpecialty> placementSpecialty = placementSpecialtyService
@@ -593,16 +532,6 @@ public class PlacementEnricherFacade {
    */
   private String getSpecialtyId(PlacementSpecialty placementSpecialty) {
     return placementSpecialty.getData().get(PLACEMENT_SPECIALTY_SPECIALITY_ID);
-  }
-
-  /**
-   * Get the Placement ID from the placement specialty.
-   *
-   * @param placementSpecialty The placement specialty to get the placement id from.
-   * @return The placement id.
-   */
-  private String getPlacementIdFromPlacementSpecialty(PlacementSpecialty placementSpecialty) {
-    return placementSpecialty.getData().get(PLACEMENT_SPECIALTY_PLACEMENT_ID);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
@@ -1,14 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package uk.nhs.hee.tis.trainee.sync.service;
 
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
@@ -23,10 +46,17 @@ public class PlacementSpecialtySyncService implements SyncService {
   private final DataRequestService dataRequestService;
   private final Set<String> requestedIds = new HashSet<>();
 
+  private final QueueMessagingTemplate messagingTemplate;
+  private final String queueUrl;
+
   PlacementSpecialtySyncService(PlacementSpecialtyRepository repository,
-      DataRequestService dataRequestService) {
+      DataRequestService dataRequestService,
+      QueueMessagingTemplate messagingTemplate,
+      @Value("${application.aws.sqs.placement-specialty}") String queueUrl) {
     this.repository = repository;
     this.dataRequestService = dataRequestService;
+    this.messagingTemplate = messagingTemplate;
+    this.queueUrl = queueUrl;
   }
 
   @Override
@@ -36,6 +66,11 @@ public class PlacementSpecialtySyncService implements SyncService {
       throw new IllegalArgumentException(message);
     }
 
+    // Send incoming placement specialty records to the placement specialty queue to be processed.
+    messagingTemplate.convertAndSend(queueUrl, placementSpecialty);
+  }
+
+  public void syncPlacementSpecialty(PlacementSpecialty placementSpecialty) {
     if (placementSpecialty.getOperation().equals(DELETE)) {
       String placementId = placementSpecialty.getData().get(PLACEMENT_ID);
       Optional<PlacementSpecialty> storedPlacementSpecialty = repository.findById(placementId);
@@ -48,7 +83,7 @@ public class PlacementSpecialtySyncService implements SyncService {
         Map<String, String> placementSpecialtyData = placementSpecialty.getData();
         String placementId = placementSpecialtyData.get(PLACEMENT_ID);
         placementSpecialty.setTisId(placementId);
-        repository.save((PlacementSpecialty) placementSpecialty);
+        repository.save(placementSpecialty);
       }
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
@@ -70,6 +70,11 @@ public class PlacementSpecialtySyncService implements SyncService {
     messagingTemplate.convertAndSend(queueUrl, placementSpecialty);
   }
 
+  /**
+   * Synchronize the given placement specialty.
+   *
+   * @param placementSpecialty The placement specialty to synchronize.
+   */
   public void syncPlacementSpecialty(PlacementSpecialty placementSpecialty) {
     if (placementSpecialty.getOperation().equals(DELETE)) {
       String placementId = placementSpecialty.getData().get(PLACEMENT_ID);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,7 @@ application:
   aws:
     sqs:
       placement: ${PLACEMENT_QUEUE_URL:}
+      placement-specialty: ${PLACEMENT_SPECIALTY_QUEUE_URL:}
       post: ${POST_QUEUE_URL:}
       record: ${RECORD_QUEUE_URL:}
       request: ${REQUEST_QUEUE_URL:}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementListenerTest.java
@@ -21,15 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Collections;
-import javax.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
@@ -44,38 +40,6 @@ class PlacementListenerTest {
   void setUp() {
     service = mock(PlacementSyncService.class);
     listener = new PlacementListener(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataNull() {
-    Placement placement = new Placement();
-    placement.setMetadata(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPlacement(placement));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenMetadataNull() {
-    Placement placement = new Placement();
-    placement.setData(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPlacement(placement));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataAndMetadataNull() {
-    Placement placement = new Placement();
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPlacement(placement));
-
-    verifyNoInteractions(service);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
@@ -75,6 +78,7 @@ class PlacementSpecialtyEventListenerTest {
     listener.onAfterSave(event);
 
     verify(messagingTemplate).convertAndSend(PLACEMENT_QUEUE_URL, placement);
+    assertThat("Unexpected table operation.", placement.getOperation(), is(Operation.LOAD));
     verify(placementService, never()).request(PLACEMENT_ID);
   }
 
@@ -103,6 +107,4 @@ class PlacementSpecialtyEventListenerTest {
     verify(enricher).restartPlacementEnrichmentIfDeletionIncorrect("40");
     verifyNoMoreInteractions(enricher);
   }
-
-
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
@@ -21,38 +21,76 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Collections;
+import java.util.Optional;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
 
 class PlacementSpecialtyEventListenerTest {
 
+  private static final String PLACEMENT_QUEUE_URL = "https://queue.placement";
+  private static final String PLACEMENT_ID = "placement1";
+
   private PlacementSpecialtyEventListener listener;
   private PlacementEnricherFacade enricher;
+  private PlacementSyncService placementService;
+  private QueueMessagingTemplate messagingTemplate;
 
   @BeforeEach
   void setUp() {
     enricher = mock(PlacementEnricherFacade.class);
-    listener = new PlacementSpecialtyEventListener(enricher);
+    placementService = mock(PlacementSyncService.class);
+    messagingTemplate = mock(QueueMessagingTemplate.class);
+    listener = new PlacementSpecialtyEventListener(enricher, placementService, messagingTemplate,
+        PLACEMENT_QUEUE_URL);
   }
 
   @Test
-  void shouldCallEnricherAfterSave() {
+  void shouldSendRelatedPlacementToQueueAfterSaveWhenPlacementFound() {
     PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    AfterSaveEvent<PlacementSpecialty> event = new AfterSaveEvent<>(placementSpecialty, null, null);
+    placementSpecialty.setData(Collections.singletonMap("placementId", PLACEMENT_ID));
 
+    Placement placement = new Placement();
+    placement.setTisId(PLACEMENT_ID);
+
+    when(placementService.findById(PLACEMENT_ID)).thenReturn(Optional.of(placement));
+
+    AfterSaveEvent<PlacementSpecialty> event = new AfterSaveEvent<>(placementSpecialty, null, null);
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(placementSpecialty);
-    verifyNoMoreInteractions(enricher);
+    verify(messagingTemplate).convertAndSend(PLACEMENT_QUEUE_URL, placement);
+    verify(placementService, never()).request(PLACEMENT_ID);
+  }
+
+  @Test
+  void shouldRequestRelatedPlacementAfterSaveWhenPlacementNotFound() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+    placementSpecialty.setData(Collections.singletonMap("placementId", PLACEMENT_ID));
+
+    when(placementService.findById(PLACEMENT_ID)).thenReturn(Optional.empty());
+
+    AfterSaveEvent<PlacementSpecialty> event = new AfterSaveEvent<>(placementSpecialty, null, null);
+    listener.onAfterSave(event);
+
+    verify(messagingTemplate, never())
+        .convertAndSend(eq(PLACEMENT_QUEUE_URL), any(Placement.class));
+    verify(placementService).request(PLACEMENT_ID);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListenerTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Collections;
+import javax.validation.ConstraintViolationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
+
+class PlacementSpecialtyListenerTest {
+
+  private PlacementSpecialtyListener listener;
+
+  private PlacementSpecialtySyncService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(PlacementSpecialtySyncService.class);
+    listener = new PlacementSpecialtyListener(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenDataNull() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+    placementSpecialty.setMetadata(Collections.emptyMap());
+
+    assertThrows(ConstraintViolationException.class,
+        () -> listener.getPlacementSpecialty(placementSpecialty));
+
+    verifyNoInteractions(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenMetadataNull() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+    placementSpecialty.setData(Collections.emptyMap());
+
+    assertThrows(ConstraintViolationException.class,
+        () -> listener.getPlacementSpecialty(placementSpecialty));
+
+    verifyNoInteractions(service);
+  }
+
+  @Disabled("Unable to get the validation working during tests.")
+  @Test
+  void shouldNotProcessRecordWhenDataAndMetadataNull() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+
+    assertThrows(ConstraintViolationException.class,
+        () -> listener.getPlacementSpecialty(placementSpecialty));
+
+    verifyNoInteractions(service);
+  }
+
+  @Test
+  void shouldProcessRecordWhenDataAndMetadataNotNull() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
+    placementSpecialty.setData(Collections.emptyMap());
+    placementSpecialty.setMetadata(Collections.emptyMap());
+
+    listener.getPlacementSpecialty(placementSpecialty);
+
+    verify(service).syncPlacementSpecialty(placementSpecialty);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyListenerTest.java
@@ -21,15 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Collections;
-import javax.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
@@ -44,41 +40,6 @@ class PlacementSpecialtyListenerTest {
   void setUp() {
     service = mock(PlacementSpecialtySyncService.class);
     listener = new PlacementSpecialtyListener(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataNull() {
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    placementSpecialty.setMetadata(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class,
-        () -> listener.getPlacementSpecialty(placementSpecialty));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenMetadataNull() {
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    placementSpecialty.setData(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class,
-        () -> listener.getPlacementSpecialty(placementSpecialty));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataAndMetadataNull() {
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-
-    assertThrows(ConstraintViolationException.class,
-        () -> listener.getPlacementSpecialty(placementSpecialty));
-
-    verifyNoInteractions(service);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostListenerTest.java
@@ -21,15 +21,11 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Collections;
-import javax.validation.ConstraintViolationException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.service.PostSyncService;
@@ -44,38 +40,6 @@ class PostListenerTest {
   void setUp() {
     service = mock(PostSyncService.class);
     listener = new PostListener(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataNull() {
-    Post post = new Post();
-    post.setMetadata(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenMetadataNull() {
-    Post post = new Post();
-    post.setData(Collections.emptyMap());
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
-
-    verifyNoInteractions(service);
-  }
-
-  @Disabled("Unable to get the validation working during tests.")
-  @Test
-  void shouldNotProcessRecordWhenDataAndMetadataNull() {
-    Post post = new Post();
-
-    assertThrows(ConstraintViolationException.class, () -> listener.getPost(post));
-
-    verifyNoInteractions(service);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -64,15 +63,11 @@ class PlacementEnricherFacadeTest {
 
   private static final String PLACEMENT_1_ID = "placement1";
   private static final String PLACEMENT_2_ID = "placement2";
-  private static final String PLACEMENT_3_ID = "placement3";
   private static final String POST_1_ID = "post1";
-  private static final String POST_2_ID = "post2";
   private static final String TRUST_1_ID = "trust1";
   private static final String TRUST_1_NAME = "Trust One";
   private static final String TRUST_2_ID = "trust2";
   private static final String TRUST_2_NAME = "Trust Two";
-  private static final String TRUST_3_ID = "trust3";
-  private static final String TRUST_3_NAME = "Trust Three";
   private static final String SITE_1_ID = "site1";
   private static final String SITE_1_NAME = "Site One";
   private static final String SITE_1_LOCATION = "Site One Location";
@@ -757,57 +752,6 @@ class PlacementEnricherFacadeTest {
   }
 
   @Test
-  void shouldNotEnrichFromPlacementSpecialtyWhenSpecialtyNotExists() {
-    Placement placement = new Placement();
-    placement.setTisId(PLACEMENT_1_ID);
-
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    placementSpecialty.setData(Map.of(
-        DATA_PLACEMENT_SPECIALTY_PLACEMENT_ID, PLACEMENT_1_ID,
-        DATA_PLACEMENT_SPECIALTY_SPECIALTY_ID, SPECIALTY_1_ID
-    ));
-
-    when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.empty());
-    when(placementService.findById(PLACEMENT_1_ID)).thenReturn(Optional.of(placement));
-
-    enricher.enrich(placementSpecialty);
-
-    verify(placementService, never()).request(anyString());
-    verify(specialtyService).request(SPECIALTY_1_ID);
-
-    verifyNoInteractions(tcsSyncService);
-
-    Map<String, String> placementData = placement.getData();
-    assertThat("Unexpected specialty name.", placementData.get(PLACEMENT_DATA_SPECIALTY_NAME),
-        nullValue());
-  }
-
-  @Test
-  void shouldNotEnrichFromPlacementSpecialtyWhenPlacementNotExists() {
-    Specialty specialty = new Specialty();
-    specialty.setTisId(SPECIALTY_1_ID);
-    specialty.setData(Map.of(
-        DATA_SPECIALTY_ID, SPECIALTY_1_ID
-    ));
-
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    placementSpecialty.setData(Map.of(
-        DATA_PLACEMENT_SPECIALTY_PLACEMENT_ID, PLACEMENT_1_ID,
-        DATA_PLACEMENT_SPECIALTY_SPECIALTY_ID, SPECIALTY_1_ID
-    ));
-
-    when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty));
-    when(placementService.findById(PLACEMENT_1_ID)).thenReturn(Optional.empty());
-
-    enricher.enrich(placementSpecialty);
-
-    verify(specialtyService, never()).request(anyString());
-    verify(placementService).request(PLACEMENT_1_ID);
-
-    verifyNoInteractions(tcsSyncService);
-  }
-
-  @Test
   void shouldNotEnrichFromSpecialtyWhenSpecialtyExistsWithoutName() {
     Specialty specialty = new Specialty();
     specialty.setTisId(SPECIALTY_1_ID);
@@ -834,40 +778,6 @@ class PlacementEnricherFacadeTest {
     Map<String, String> placement1Data = placement1.getData();
     assertThat("Unexpected specialty name.", placement1Data.get(PLACEMENT_DATA_SPECIALTY_NAME),
         nullValue());
-  }
-
-  @Test
-  void shouldEnrichFromPlacementSpecialtyWhenSpecialtyExists() {
-    Specialty specialty = new Specialty();
-    specialty.setTisId(SPECIALTY_1_ID);
-    specialty.setData(Map.of(
-        DATA_SPECIALTY_ID, SPECIALTY_1_ID,
-        DATA_SPECIALTY_NAME, SPECIALTY_1_NAME
-    ));
-
-    Placement placement = new Placement();
-    placement.setTisId(PLACEMENT_1_ID);
-
-    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
-    placementSpecialty.setData(Map.of(
-        DATA_PLACEMENT_SPECIALTY_PLACEMENT_ID, PLACEMENT_1_ID,
-        DATA_PLACEMENT_SPECIALTY_SPECIALTY_ID, SPECIALTY_1_ID
-    ));
-
-    when(placementService.findById(PLACEMENT_1_ID)).thenReturn(Optional.of(placement));
-    when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty));
-
-    enricher.enrich(placementSpecialty);
-
-    verify(placementService, never()).request(anyString());
-    verify(specialtyService, never()).request(anyString());
-
-    verify(tcsSyncService).syncRecord(placement);
-    verifyNoMoreInteractions(tcsSyncService);
-
-    Map<String, String> placementData = placement.getData();
-    assertThat("Unexpected specialty name.", placementData.get(PLACEMENT_DATA_SPECIALTY_NAME),
-        is(SPECIALTY_1_NAME));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
@@ -110,7 +110,9 @@ class PlacementSpecialtySyncServiceTest {
     assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
   }
 
-  @ParameterizedTest(name = "Should send placement specialty records to queue when operation is {0}.")
+  @ParameterizedTest(
+      name = "Should send placement specialty records to queue when operation is {0}."
+  )
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldSendPlacementSpecialtyRecordsToQueue(Operation operation) {
     placementSpecialty.setOperation(operation);


### PR DESCRIPTION
Rather than trigger enrichment when a PlacementSpecialty is recieved, it
should queue or request the associated placement (depending if it
exists).
When a PlacementSpecialty is received on the record queue, requeue it on
the PlacementSpecialty queue.

TIS21-1693