### PR TITLE
feat: Expand Specialty to PlacementSpecialty queue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.21.0"
+version = "0.22.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
@@ -1,19 +1,33 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.model.Specialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
 
 @Component
 public class SpecialtyEventListener extends AbstractMongoEventListener<Specialty> {
 
-  private final PlacementEnricherFacade placementEnricher;
+  private final PlacementSpecialtySyncService placementSpecialtyService;
 
-  SpecialtyEventListener(PlacementEnricherFacade placementEnricher) {
-    this.placementEnricher = placementEnricher;
+  private final QueueMessagingTemplate messagingTemplate;
+
+  private final String placementSpecialtyQueueUrl;
+
+  SpecialtyEventListener(PlacementSpecialtySyncService placementSpecialtyService,
+      QueueMessagingTemplate messagingTemplate,
+      @Value("${application.aws.sqs.placement-specialty}") String placementSpecialtyQueueUrl
+  ) {
+    this.placementSpecialtyService = placementSpecialtyService;
+    this.messagingTemplate = messagingTemplate;
+    this.placementSpecialtyQueueUrl = placementSpecialtyQueueUrl;
   }
 
   @Override
@@ -21,7 +35,14 @@ public class SpecialtyEventListener extends AbstractMongoEventListener<Specialty
     super.onAfterSave(event);
 
     Specialty specialty = event.getSource();
-    placementEnricher.enrich(specialty);
+    Set<PlacementSpecialty> placementSpecialties = placementSpecialtyService
+        .findPrimaryPlacementSpecialtiesBySpecialtyId(specialty.getTisId());
+
+    for (PlacementSpecialty placementSpecialty : placementSpecialties) {
+      // Default each placement specialty to LOAD.
+      placementSpecialty.setOperation(Operation.LOAD);
+      messagingTemplate.convertAndSend(placementSpecialtyQueueUrl, placementSpecialty);
+    }
   }
 
   @Override

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
@@ -1,34 +1,76 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Collections;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import uk.nhs.hee.tis.trainee.sync.facade.PlacementEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.model.Specialty;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSpecialtySyncService;
 
 class SpecialtyEventListenerTest {
 
+  private static final String PLACEMENT_SPECIALTY_QUEUE_URL = "https://queue.placement-specialty";
+
   private SpecialtyEventListener listener;
-  private PlacementEnricherFacade enricher;
+  private PlacementSpecialtySyncService placementSpecialtyService;
+  private QueueMessagingTemplate messagingTemplate;
 
   @BeforeEach
   void setUp() {
-    enricher = mock(PlacementEnricherFacade.class);
-    listener = new SpecialtyEventListener(enricher);
+    placementSpecialtyService = mock(PlacementSpecialtySyncService.class);
+    messagingTemplate = mock(QueueMessagingTemplate.class);
+    listener = new SpecialtyEventListener(placementSpecialtyService, messagingTemplate,
+        PLACEMENT_SPECIALTY_QUEUE_URL);
   }
 
   @Test
-  void shouldCallEnricherAfterSave() {
+  void shouldNotInteractWithPlacementSpecialtyQueueAfterSaveWhenNoRelatedPlacementSpecialties() {
     Specialty specialty = new Specialty();
+    specialty.setTisId("specialty1");
     AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(specialty, null, null);
+
+    when(placementSpecialtyService.findPrimaryPlacementSpecialtiesBySpecialtyId("specialty1"))
+        .thenReturn(Collections.emptySet());
 
     listener.onAfterSave(event);
 
-    verify(enricher).enrich(specialty);
-    verifyNoMoreInteractions(enricher);
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldSendRelatedPlacementSpecialtiesToQueueAfterSaveWhenRelatedPlacementSpecialties() {
+    Specialty specialty = new Specialty();
+    specialty.setTisId("specialty1");
+
+    PlacementSpecialty placementSpecialty1 = new PlacementSpecialty();
+    placementSpecialty1.setTisId("placementSpecialty1");
+
+    PlacementSpecialty placementSpecialty2 = new PlacementSpecialty();
+    placementSpecialty2.setTisId("placementSpecialty2");
+
+    when(placementSpecialtyService.findPrimaryPlacementSpecialtiesBySpecialtyId("specialty1"))
+        .thenReturn(Set.of(placementSpecialty1, placementSpecialty2));
+
+    AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(specialty, null, null);
+    listener.onAfterSave(event);
+
+    verify(messagingTemplate).convertAndSend(PLACEMENT_SPECIALTY_QUEUE_URL, placementSpecialty1);
+    assertThat("Unexpected table operation.", placementSpecialty1.getOperation(),
+        is(Operation.LOAD));
+
+    verify(messagingTemplate).convertAndSend(PLACEMENT_SPECIALTY_QUEUE_URL, placementSpecialty2);
+    assertThat("Unexpected table operation.", placementSpecialty2.getOperation(),
+        is(Operation.LOAD));
   }
 }


### PR DESCRIPTION
When a specialty is updated the enricher gets all related placement
specialties and attempts to process them together, due to the amount of
time it can take to process large specialties this approach can cause
issues.
Placement specialties related to the updated specialty should instead be
queued up in the placement specialty queue, which in turn will handle
the associated placements.

TIS21-1692