### PR TITLE
Feat: ProgrammeMembership to CurriculumMembership

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.28.1"
+version = "0.29.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -86,7 +86,7 @@ public class TraineeDetailsDto {
   private String employingBody;
   private String trainingBody;
 
-  //ProgrammeMembership fields.
+  //ProgrammeMembership or CurriculumMembership fields.
   private String programmeName;
   private String programmeNumber;
   private String programmeTisId;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
@@ -26,18 +26,18 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 
 @Component
 public class CurriculumEventListener extends AbstractMongoEventListener<Curriculum> {
 
-  private final ProgrammeMembershipEnricherFacade programmeMembershipEnricher;
+  private final CurriculumMembershipEnricherFacade curriculumMembershipEnricher;
   private final Cache cache;
 
-  CurriculumEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher,
+  CurriculumEventListener(CurriculumMembershipEnricherFacade curriculumMembershipEnricher,
       CacheManager cacheManager) {
-    this.programmeMembershipEnricher = programmeMembershipEnricher;
+    this.curriculumMembershipEnricher = curriculumMembershipEnricher;
     cache = cacheManager.getCache(Curriculum.ENTITY_NAME);
   }
 
@@ -47,6 +47,6 @@ public class CurriculumEventListener extends AbstractMongoEventListener<Curricul
 
     Curriculum curriculum = event.getSource();
     cache.put(curriculum.getTisId(), curriculum);
-    programmeMembershipEnricher.enrich(curriculum);
+    curriculumMembershipEnricher.enrich(curriculum);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -88,7 +88,8 @@ public class CurriculumMembershipEventListener
   public void onAfterDelete(AfterDeleteEvent<CurriculumMembership> event) {
     super.onAfterDelete(event);
     CurriculumMembership curriculumMembership =
-        curriculumMembershipCache.get(event.getSource().getString("_id"), CurriculumMembership.class);
+        curriculumMembershipCache.get(event.getSource().getString("_id"),
+            CurriculumMembership.class);
     if (curriculumMembership != null) {
       curriculumMembershipEnricher.delete(curriculumMembership);
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -31,7 +31,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
 
 @Component

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -49,7 +49,7 @@ public class CurriculumMembershipEventListener
                                    CacheManager cacheManager) {
     this.curriculumMembershipEnricher = curriculumMembershipEnricher;
     this.curriculumMembershipSyncService = curriculumMembershipSyncService;
-    curriculumMembershipCache = cacheManager.getCache(ProgrammeMembership.ENTITY_NAME);
+    curriculumMembershipCache = cacheManager.getCache(CurriculumMembership.ENTITY_NAME);
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import java.util.Optional;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
+
+@Component
+public class CurriculumMembershipEventListener
+    extends AbstractMongoEventListener<CurriculumMembership> {
+
+  private final ProgrammeMembershipEnricherFacade programmeMembershipEnricher;
+
+  private CurriculumMembershipSyncService curriculumMembershipSyncService;
+
+  private Cache curriculumMembershipCache;
+
+  CurriculumMembershipEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher,
+                                    CurriculumMembershipSyncService curriculumMembershipSyncService,
+                                   CacheManager cacheManager) {
+    this.programmeMembershipEnricher = programmeMembershipEnricher;
+    this.curriculumMembershipSyncService = curriculumMembershipSyncService;
+    curriculumMembershipCache = cacheManager.getCache(ProgrammeMembership.ENTITY_NAME);
+  }
+
+  @Override
+  public void onAfterSave(AfterSaveEvent<CurriculumMembership> event) {
+    super.onAfterSave(event);
+
+    CurriculumMembership curriculumMembership = event.getSource();
+    //TODO: convert to programmeMembership? or (ugh) copy-paste new enricher?
+    //the existing enricher uses the programmeMembershipSyncService so it will not be pulling the
+    //data from the correct db table
+    programmeMembershipEnricher.enrich(curriculumMembership);
+  }
+
+  /**
+   * Before deleting a curriculum membership, ensure it is cached.
+   *
+   * @param event The before-delete event for the curriculum membership.
+   *
+   *              Note: if a curriculum membership is part of an aggregate (i.e. multiple-curricula)
+   *              curriculum membership, then the saved (and hence cached) curriculum membership is
+   *              the aggregate version. This will have a key like '310640,310641'. Here we cache
+   *              the individual curriculum membership, which would have a key like '310640', so
+   *              that it can be successfully retrieved in the onAfterDelete event.
+   */
+  @Override
+  public void onBeforeDelete(BeforeDeleteEvent<CurriculumMembership> event) {
+    String id = event.getSource().getString("_id");
+    CurriculumMembership curriculumMembership =
+        curriculumMembershipCache.get(id, CurriculumMembership.class);
+    if (curriculumMembership == null) {
+      Optional<CurriculumMembership> newCurriculumMembership =
+          curriculumMembershipSyncService.findById(id);
+      newCurriculumMembership.ifPresent(membership ->
+          curriculumMembershipCache.put(id, membership));
+    }
+  }
+
+  @Override
+  public void onAfterDelete(AfterDeleteEvent<CurriculumMembership> event) {
+    super.onAfterDelete(event);
+    CurriculumMembership curriculumMembership =
+        curriculumMembershipCache.get(event.getSource().getString("_id"), CurriculumMembership.class);
+    if (curriculumMembership != null) {
+      //TODO: convert to programmeMembership or (ugh) copy-paste enricher?
+      programmeMembershipEnricher.delete(curriculumMembership);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -29,26 +29,25 @@ import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
-import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
 
 @Component
 public class CurriculumMembershipEventListener
     extends AbstractMongoEventListener<CurriculumMembership> {
 
-  private final ProgrammeMembershipEnricherFacade programmeMembershipEnricher;
+  private final CurriculumMembershipEnricherFacade curriculumMembershipEnricher;
 
   private CurriculumMembershipSyncService curriculumMembershipSyncService;
 
   private Cache curriculumMembershipCache;
 
-  CurriculumMembershipEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher,
+  CurriculumMembershipEventListener(CurriculumMembershipEnricherFacade curriculumMembershipEnricher,
                                     CurriculumMembershipSyncService curriculumMembershipSyncService,
                                    CacheManager cacheManager) {
-    this.programmeMembershipEnricher = programmeMembershipEnricher;
+    this.curriculumMembershipEnricher = curriculumMembershipEnricher;
     this.curriculumMembershipSyncService = curriculumMembershipSyncService;
     curriculumMembershipCache = cacheManager.getCache(ProgrammeMembership.ENTITY_NAME);
   }
@@ -58,10 +57,7 @@ public class CurriculumMembershipEventListener
     super.onAfterSave(event);
 
     CurriculumMembership curriculumMembership = event.getSource();
-    //TODO: convert to programmeMembership? or (ugh) copy-paste new enricher?
-    //the existing enricher uses the programmeMembershipSyncService so it will not be pulling the
-    //data from the correct db table
-    programmeMembershipEnricher.enrich(curriculumMembership);
+    curriculumMembershipEnricher.enrich(curriculumMembership);
   }
 
   /**
@@ -94,8 +90,7 @@ public class CurriculumMembershipEventListener
     CurriculumMembership curriculumMembership =
         curriculumMembershipCache.get(event.getSource().getString("_id"), CurriculumMembership.class);
     if (curriculumMembership != null) {
-      //TODO: convert to programmeMembership or (ugh) copy-paste enricher?
-      programmeMembershipEnricher.delete(curriculumMembership);
+      curriculumMembershipEnricher.delete(curriculumMembership);
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListener.java
@@ -24,16 +24,16 @@ package uk.nhs.hee.tis.trainee.sync.event;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 
 @Component
 public class ProgrammeEventListener extends AbstractMongoEventListener<Programme> {
 
-  private final ProgrammeMembershipEnricherFacade programmeMembershipEnricher;
+  private final CurriculumMembershipEnricherFacade curriculumMembershipEnricher;
 
-  ProgrammeEventListener(ProgrammeMembershipEnricherFacade programmeMembershipEnricher) {
-    this.programmeMembershipEnricher = programmeMembershipEnricher;
+  ProgrammeEventListener(CurriculumMembershipEnricherFacade curriculumMembershipEnricher) {
+    this.curriculumMembershipEnricher = curriculumMembershipEnricher;
   }
 
   @Override
@@ -41,6 +41,6 @@ public class ProgrammeEventListener extends AbstractMongoEventListener<Programme
     super.onAfterSave(event);
 
     Programme programme = event.getSource();
-    programmeMembershipEnricher.enrich(programme);
+    curriculumMembershipEnricher.enrich(programme);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
@@ -1,0 +1,729 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.facade;
+
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOAD;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
+import uk.nhs.hee.tis.trainee.sync.model.Programme;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.TcsSyncService;
+
+@Component
+@Slf4j
+public class CurriculumMembershipEnricherFacade {
+
+  private static final String CURRICULUM_MEMBERSHIP_PROGRAMME_ID = "programmeId";
+  private static final String CURRICULUM_MEMBERSHIP_CURRICULUM_ID = "curriculumId";
+  private static final String CURRICULUM_MEMBERSHIP_PERSON_ID = "personId";
+  private static final String CURRICULUM_MEMBERSHIP_PROGRAMME_MEMBERSHIP_TYPE =
+      "programmeMembershipType";
+  private static final String CURRICULUM_MEMBERSHIP_PROGRAMME_COMPLETION_DATE =
+      "programmeCompletionDate";
+  private static final String CURRICULUM_MEMBERSHIP_PROGRAMME_START_DATE = "programmeStartDate";
+  private static final String CURRICULUM_MEMBERSHIP_PROGRAMME_END_DATE = "programmeEndDate";
+  private static final String CURRICULUM_MEMBERSHIP_CURRICULA = "curricula";
+
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME = "programmeName";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_TIS_ID = "programmeTisId";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NUMBER = "programmeNumber";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_MANAGING_DEANERY = "managingDeanery";
+
+  private static final String PROGRAMME_NAME = "programmeName";
+  private static final String PROGRAMME_NUMBER = "programmeNumber";
+  private static final String MANAGING_DEANERY = "owner";
+
+  private static final String CURRICULUM_DATA_TIS_ID = "curriculumTisId";
+  private static final String CURRICULUM_DATA_NAME = "curriculumName";
+  private static final String CURRICULUM_DATA_SUB_TYPE = "curriculumSubType";
+  private static final String CURRICULUM_DATA_START_DATE = "curriculumStartDate";
+  private static final String CURRICULUM_DATA_END_DATE = "curriculumEndDate";
+  // from programme membership
+
+  private static final String CURRICULUM_NAME = "name";
+  private static final String CURRICULUM_SUB_TYPE = "curriculumSubType";
+  private static final String CURRICULUM_START_DATE = "curriculumStartDate";
+  private static final String CURRICULUM_END_DATE = "curriculumEndDate";
+  // from programme membership
+
+  private final CurriculumMembershipSyncService curriculumMembershipSyncService;
+  private final ProgrammeSyncService programmeSyncService;
+  private final CurriculumSyncService curriculumSyncService;
+
+  private final TcsSyncService tcsSyncService;
+
+  CurriculumMembershipEnricherFacade(CurriculumMembershipSyncService curriculumMembershipSyncService,
+                                    ProgrammeSyncService programmeSyncService,
+                                    CurriculumSyncService curriculumSyncService,
+                                    TcsSyncService tcsSyncService) {
+    this.curriculumMembershipSyncService = curriculumMembershipSyncService;
+    this.programmeSyncService = programmeSyncService;
+    this.curriculumSyncService = curriculumSyncService;
+    this.tcsSyncService = tcsSyncService;
+  }
+
+  /**
+   * Delete a curriculumMembership from tis-trainee-details.
+   *
+   * @param curriculumMembership The curriculum membership to delete.
+   */
+  public void delete(CurriculumMembership curriculumMembership) {
+
+    deleteAllPersonsCurriculumMemberships(curriculumMembership);
+
+    HashSet<String> curriculumMembershipsSynced = new HashSet<>();
+
+    Set<CurriculumMembership> allTheirOtherCurriculumMemberships =
+        curriculumMembershipSyncService.findByPersonId(getPersonId(curriculumMembership));
+
+    for (CurriculumMembership theirCurriculumMembership : allTheirOtherCurriculumMemberships) {
+      String similarKey = getCurriculumMembershipsSimilarKey(theirCurriculumMembership);
+      if (!curriculumMembershipsSynced.contains(similarKey)) {
+        enrich(theirCurriculumMembership, true, true, false);
+        curriculumMembershipsSynced.add(similarKey);
+      }
+    }
+  }
+
+  /**
+   * Sync an enriched curriculumMembership with the associated curriculum as the starting point.
+   *
+   * @param curriculum The curriculum triggering curriculum membership enrichment.
+   */
+  public void enrich(Curriculum curriculum) {
+    final String finalCurriculumName = getCurriculumName(curriculum);
+    final String finalCurriculumSubType = getCurriculumSubType(curriculum);
+    final String finalCurriculumTisId = curriculum.getTisId();
+
+    if (finalCurriculumName != null || finalCurriculumSubType != null) {
+      Set<CurriculumMembership> curriculumMemberships =
+          curriculumMembershipSyncService.findByCurriculumId(finalCurriculumTisId);
+
+      curriculumMemberships.forEach(
+          curriculumMembership -> {
+            populateCurriculumDetails(curriculumMembership, finalCurriculumTisId,
+                finalCurriculumName, finalCurriculumSubType);
+            enrich(curriculumMembership, true, false, false);
+          }
+      );
+    }
+  }
+
+  /**
+   * Sync an enriched curriculumMembership with the associated programme as the starting point.
+   *
+   * @param programme The programme triggering curriculum membership enrichment.
+   */
+  public void enrich(Programme programme) {
+    final String finalProgrammeName = getProgrammeName(programme);
+    final String finalProgrammeTisId = programme.getTisId();
+    final String finalProgrammeNumber = getProgrammeNumber(programme);
+    final String finalManagingDeanery = getManagingDeanery(programme);
+
+    if (finalProgrammeName != null || finalProgrammeTisId != null || finalProgrammeNumber != null
+        || finalManagingDeanery != null) {
+      Set<CurriculumMembership> curriculumMemberships =
+          curriculumMembershipSyncService.findByProgrammeId(finalProgrammeTisId);
+
+      curriculumMemberships.forEach(
+          curriculumMembership -> {
+            populateProgrammeDetails(curriculumMembership, finalProgrammeName, finalProgrammeTisId,
+                finalProgrammeNumber, finalManagingDeanery);
+            enrich(curriculumMembership, false, true, false);
+          }
+      );
+    }
+  }
+
+  /**
+   * Sync an enriched curriculumMembership with the curriculumMembership as the starting object.
+   *
+   * @param curriculumMembership The curriculumMembership to enrich.
+   */
+  public void enrich(CurriculumMembership curriculumMembership) {
+    enrich(curriculumMembership, true, true, true);
+  }
+
+  /**
+   * Sync an enriched curriculumMembership with the curriculumMembership. Optionally enrich programme
+   * or curriculum details. Optionally completely resync all programme memberships for the person
+   *
+   * @param curriculumMembership                 The curriculumMembership to enrich.
+   * @param doProgrammeEnrich                    Enrich programme details
+   * @param doCurriculumEnrich                   Enrich curriculum details
+   * @param doRebuildPersonsCurriculumMemberships Rebuild all curriculum memberships for person
+   */
+  private void enrich(CurriculumMembership curriculumMembership,
+                      boolean doProgrammeEnrich,
+                      boolean doCurriculumEnrich,
+                      boolean doRebuildPersonsCurriculumMemberships) {
+    boolean doSync = true;
+
+    if (doProgrammeEnrich) {
+      String programmeId = getProgrammeId(curriculumMembership);
+
+      if (programmeId != null) {
+        Optional<Programme> optionalProgramme = programmeSyncService.findById(programmeId);
+
+        if (optionalProgramme.isPresent()) {
+          doSync = enrich(curriculumMembership, optionalProgramme.get());
+        } else {
+          programmeSyncService.request(programmeId);
+          doSync = false;
+        }
+      }
+    }
+
+    if (doCurriculumEnrich) {
+      String curriculumId = getCurriculumId(curriculumMembership);
+
+      if (curriculumId != null) {
+        Optional<Curriculum> optionalCurriculum = curriculumSyncService.findById(curriculumId);
+
+        if (optionalCurriculum.isPresent()) {
+          doSync &= enrich(curriculumMembership, optionalCurriculum.get());
+        } else {
+          curriculumSyncService.request(curriculumId);
+          doSync = false;
+        }
+      }
+    }
+
+    if (doSync) {
+      syncAggregateCurriculumMembership(curriculumMembership,
+          doRebuildPersonsCurriculumMemberships);
+    }
+  }
+
+  /**
+   * Enrich the curriculumMembership with details from the Curriculum.
+   *
+   * @param curriculumMembership The curriculumMembership to enrich.
+   * @param curriculum          The curriculum to enrich the curriculumMembership with.
+   * @return Whether enrichment was successful.
+   */
+  private boolean enrich(CurriculumMembership curriculumMembership, Curriculum curriculum) {
+
+    String curriculumName = getCurriculumName(curriculum);
+    String curriculumTisId = curriculum.getTisId();
+    String curriculumSubType = getCurriculumSubType(curriculum);
+
+    if (curriculumName != null) {
+      populateCurriculumDetails(curriculumMembership, curriculumTisId, curriculumName,
+          curriculumSubType);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Enrich the curriculumMembership with details from the Programme.
+   *
+   * @param curriculumMembership The curriculumMembership to enrich.
+   * @param programme           The programme to enrich the curriculumMembership with.
+   * @return Whether enrichment was successful.
+   */
+  private boolean enrich(CurriculumMembership curriculumMembership, Programme programme) {
+
+    String programmeName = getProgrammeName(programme);
+    String programmeTisId = programme.getTisId();
+    String programmeNumber = getProgrammeNumber(programme);
+    String managingDeanery = getManagingDeanery(programme);
+
+    if (programmeName != null || programmeTisId != null || programmeNumber != null
+        || managingDeanery != null) {
+      populateProgrammeDetails(curriculumMembership, programmeName, programmeTisId, programmeNumber,
+          managingDeanery);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Sync the aggregated curriculumMembership.
+   *
+   * @param aggregateCurriculumMembership         The aggregated curriculumMembership to sync.
+   * @param doRebuildPersonsCurriculumMemberships Re-sync all PMs for the person.
+   */
+  void syncAggregateCurriculumMembership(CurriculumMembership aggregateCurriculumMembership,
+                                         boolean doRebuildPersonsCurriculumMemberships) {
+    if (doRebuildPersonsCurriculumMemberships) {
+      deleteAllPersonsCurriculumMemberships(aggregateCurriculumMembership);
+
+      HashSet<String> curriculumMembershipsSynced = new HashSet<>();
+      syncCurriculumMembership(aggregateCurriculumMembership);
+      curriculumMembershipsSynced
+          .add(getCurriculumMembershipsSimilarKey(aggregateCurriculumMembership));
+
+      Set<CurriculumMembership> allTheirCurriculumMemberships =
+          curriculumMembershipSyncService.findByPersonId(getPersonId(aggregateCurriculumMembership));
+
+      for (CurriculumMembership theirCurriculumMembership : allTheirCurriculumMemberships) {
+        if (!curriculumMembershipsSynced
+            .contains(getCurriculumMembershipsSimilarKey(theirCurriculumMembership))) {
+          enrich(theirCurriculumMembership, true, true, false);
+          curriculumMembershipsSynced
+              .add(getCurriculumMembershipsSimilarKey(theirCurriculumMembership));
+        }
+      }
+    } else {
+      syncCurriculumMembership(aggregateCurriculumMembership);
+    }
+  }
+
+  /**
+   * Enrich the curriculumMembership with the given programme name, TIS ID, number and managing
+   * deanery and then sync it.
+   *
+   * @param curriculumMembership The curriculumMembership to sync.
+   * @param curriculumName      The curriculum name to enrich with.
+   */
+  private void populateCurriculumDetails(CurriculumMembership curriculumMembership,
+                                         String curriculumTisId,
+                                         String curriculumName,
+                                         String curriculumSubType) {
+    // Add extra data to curriculumMembership data. This is unpacked again in
+    // syncCurriculumMembership(CurriculumMembership curriculumMembership)
+    // to derive the aggregate curriculumMembership record.
+    if (Strings.isNotBlank(curriculumName)) {
+      Map<String, String> c = new HashMap<>();
+      c.put(CURRICULUM_DATA_NAME, curriculumName);
+      c.put(CURRICULUM_DATA_TIS_ID, curriculumTisId);
+      c.put(CURRICULUM_DATA_SUB_TYPE, curriculumSubType);
+      c.put(CURRICULUM_DATA_START_DATE, getCurriculumStartDate(curriculumMembership));
+      c.put(CURRICULUM_DATA_END_DATE, getCurriculumEndDate(curriculumMembership));
+
+      Set<Map<String, String>> curricula = new HashSet<>();
+      curricula.add(c);
+
+      String curriculaJson = getCurriculaJson(curricula);
+
+      curriculumMembership.getData().put(CURRICULUM_MEMBERSHIP_CURRICULA, curriculaJson);
+    }
+  }
+
+  /**
+   * Enrich the curriculumMembership with the given programme name, TIS ID, number and managing
+   * deanery and then sync it.
+   *
+   * @param curriculumMembership The curriculumMembership to sync.
+   * @param programmeName       The programme name to enrich with.
+   * @param programmeTisId      The programme TIS ID to enrich with.
+   * @param programmeName       The programme name to enrich with.
+   * @param programmeNumber     The programme number to enrich with.
+   * @param managingDeanery     The managing deanery to enrich with.
+   */
+  private void populateProgrammeDetails(CurriculumMembership curriculumMembership,
+                                        String programmeName,
+                                        String programmeTisId,
+                                        String programmeNumber,
+                                        String managingDeanery) {
+    // Add extra data to curriculumMembership data.
+    if (Strings.isNotBlank(programmeName)) {
+      curriculumMembership.getData()
+          .put(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME, programmeName);
+    }
+    if (Strings.isNotBlank(programmeTisId)) {
+      curriculumMembership.getData()
+          .put(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_TIS_ID, programmeTisId);
+    }
+    if (Strings.isNotBlank(programmeNumber)) {
+      curriculumMembership.getData()
+          .put(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NUMBER, programmeNumber);
+    }
+    if (Strings.isNotBlank(managingDeanery)) {
+      curriculumMembership.getData()
+          .put(CURRICULUM_MEMBERSHIP_DATA_MANAGING_DEANERY, managingDeanery);
+    }
+  }
+
+  /**
+   * Sync the (completely enriched) curriculumMembership, aggregating with similar
+   * curriculumMemberships.
+   * Note: 'similar' is defined as sharing the same personId,
+   * programmeId, programmeStartDate, programmeEndDate and
+   * programmeMembershipType.
+   * @param curriculumMembership The curriculumMembership to sync.
+   */
+  private void syncCurriculumMembership(CurriculumMembership curriculumMembership) {
+    // Set the required metadata so the record can be synced using common logic.
+    curriculumMembership.setOperation(LOAD);
+    curriculumMembership.setSchema("tcs");
+    curriculumMembership.setTable("CurriculumMembership");
+
+    // first get all similar curriculumMemberships
+    Set<CurriculumMembership> curriculumMemberships =
+        getCurriculumMembershipsSimilarTo(curriculumMembership);
+
+    // initialise properties that will be aggregated
+    // TIS ID
+    Set<String> tisIds = new HashSet<>();
+    tisIds.add(curriculumMembership.getTisId());
+    // programmeCompletionDate
+    String programmeCompletionDate = getProgrammeCompletionDate(curriculumMembership);
+    LocalDate maxProgrammeCompletionDate =
+        programmeCompletionDate == null ? null : LocalDate.parse(programmeCompletionDate);
+    //curricula
+    Set<Map<String, String>> allCurricula = getCurricula(curriculumMembership);
+
+    // it is possible for the similar programmeMemberships to reference data (e.g. curricula)
+    // we do not yet have in the local store, in which case the sync will be aborted
+    boolean doSync = true;
+
+    // traverse the similar programmeMemberships to derive the aggregate properties
+    for (CurriculumMembership thisCurriculumMembership : curriculumMemberships) {
+
+      // TIS ID
+      tisIds.add(thisCurriculumMembership.getTisId());
+
+      // programmeCompletionDate
+      maxProgrammeCompletionDate = getNewMaximumProgrammeCompletionDate(maxProgrammeCompletionDate,
+          thisCurriculumMembership);
+
+      // curricula
+      String curriculumId = getCurriculumId(thisCurriculumMembership);
+      if (curriculumId != null) {
+        Optional<Curriculum> optionalCurriculum = curriculumSyncService.findById(curriculumId);
+
+        if (optionalCurriculum.isPresent()) {
+          enrich(thisCurriculumMembership, optionalCurriculum.get());
+        } else {
+          doSync = false;
+          break;
+          // Cannot sync this record because all the related curriculum data is not available in
+          // local store.
+          // Note that we don't need to worry about programme data availability, since by definition
+          // curriculumMemberships will all have the same programmeId as curriculumMembership, which
+          // has already been successfully enriched with locally-held programme data.
+        }
+      }
+      Set<Map<String, String>> thisCurricula = getCurricula(thisCurriculumMembership);
+      allCurricula.addAll(thisCurricula);
+    }
+
+    if (doSync) {
+      // final preparation and insertion of aggregate data
+
+      //TIS ID
+      List<String> sortedTisIds = new ArrayList<>(tisIds);
+      Collections.sort(sortedTisIds);
+      String allSortedTisIds = String.join(",", sortedTisIds);
+      curriculumMembership.setTisId(allSortedTisIds);
+
+      // programmeCompletionDate
+      curriculumMembership.getData().put(
+          CURRICULUM_MEMBERSHIP_PROGRAMME_COMPLETION_DATE,
+          String.valueOf(maxProgrammeCompletionDate));
+
+      // curricula
+      String allCurriculaJson = getCurriculaJson(allCurricula);
+      curriculumMembership.getData().put(
+          CURRICULUM_MEMBERSHIP_CURRICULA,
+          allCurriculaJson);
+
+      // sync the complete aggregate curriculumMembership record
+      tcsSyncService.syncRecord(curriculumMembership);
+    }
+  }
+
+  /**
+   * Delete all curriculumMemberships for the person.
+   *
+   * @param curriculumMembership The curriculum membership to retrieve the person from
+   */
+  private void deleteAllPersonsCurriculumMemberships(CurriculumMembership curriculumMembership) {
+    curriculumMembership.setOperation(DELETE);
+    curriculumMembership.setSchema("tcs");
+    curriculumMembership.setTable("CurriculumMembership");
+    tcsSyncService.syncRecord(curriculumMembership); // delete all curriculum memberships for personId
+  }
+
+  /**
+   * Get the greater (most recent) date from a current maximum date and a curriculumMembership's
+   * completion date.
+   *
+   * @param currentMaximumDate  The current maximum date
+   * @param curriculumMembership The curriculum membership to retrieve the completion date from.
+   * @return The new maximum date.
+   */
+  private LocalDate getNewMaximumProgrammeCompletionDate(LocalDate currentMaximumDate,
+                                                         CurriculumMembership curriculumMembership) {
+    LocalDate newMaximumDate = currentMaximumDate;
+    String programmeCompletionDateString = getProgrammeCompletionDate(curriculumMembership);
+    if (programmeCompletionDateString != null) {
+      LocalDate programmeCompletionDate = LocalDate.parse(programmeCompletionDateString);
+      if (currentMaximumDate == null || programmeCompletionDate.isAfter(currentMaximumDate)) {
+        newMaximumDate = programmeCompletionDate;
+      }
+    }
+    return newMaximumDate;
+  }
+
+  /**
+   * Get the curriculum memberships similar to the passed curriculum membership.
+   * Note: 'similar' is defined as sharing the same personId, programmeId, programmeStartDate,
+   * programmeEndDate and programmeMembershipType.
+   * @param curriculumMembership The curriculum membership to use as the criteria
+   * @return The set of similar curriculum memberships.
+   */
+  private Set<CurriculumMembership> getCurriculumMembershipsSimilarTo(
+      CurriculumMembership curriculumMembership) {
+    String personId = getPersonId(curriculumMembership);
+    String programmeId = getProgrammeId(curriculumMembership);
+    String programmeMembershipType = getProgrammeMembershipType(curriculumMembership);
+    String programmeStartDate = getProgrammeStartDate(curriculumMembership);
+    String programmeEndDate = getProgrammeEndDate(curriculumMembership);
+
+    return curriculumMembershipSyncService.findBySimilar(personId, programmeId, programmeMembershipType,
+        programmeStartDate, programmeEndDate);
+  }
+
+  /**
+   * Get the curriculum memberships similarity key.
+   * Note: 'similar' means sharing the same personId, programmeId, programmeStartDate,
+   * programmeEndDate and programmeMembershipType.
+   * @param curriculumMembership The curriculum membership to use as the criteria
+   * @return The similarity key.
+   */
+  private String getCurriculumMembershipsSimilarKey(CurriculumMembership curriculumMembership) {
+    String personId = getPersonId(curriculumMembership);
+    String programmeId = getProgrammeId(curriculumMembership);
+    String programmeMembershipType = getProgrammeMembershipType(curriculumMembership);
+    String programmeStartDate = getProgrammeStartDate(curriculumMembership);
+    String programmeEndDate = getProgrammeEndDate(curriculumMembership);
+
+    StringBuilder key = new StringBuilder();
+    key.append(personId);
+    key.append(".");
+    key.append(programmeId);
+    key.append(".");
+    key.append(programmeMembershipType);
+    key.append(".");
+    key.append(programmeStartDate);
+    key.append(".");
+    key.append(programmeEndDate);
+    return key.toString();
+  }
+
+  /**
+   * Get the Programme Name for the programme.
+   *
+   * @param programme The programme to get the name from.
+   * @return The programme name.
+   */
+  private String getProgrammeName(Programme programme) {
+    return programme.getData().get(PROGRAMME_NAME);
+  }
+
+  /**
+   * Get the Programme Number for the programme.
+   *
+   * @param programme The programme to get the number from.
+   * @return The programme number.
+   */
+  private String getProgrammeNumber(Programme programme) {
+    return programme.getData().get(PROGRAMME_NUMBER);
+  }
+
+  /**
+   * Get the Managing Deanery for the programme.
+   *
+   * @param programme The programme to get the owner from.
+   * @return The managing deanery.
+   */
+  private String getManagingDeanery(Programme programme) {
+    return programme.getData().get(MANAGING_DEANERY);
+  }
+
+  /**
+   * Get the Programme ID from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the programme id from.
+   * @return The programme id.
+   */
+  private String getProgrammeId(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PROGRAMME_ID);
+  }
+
+  /**
+   * Get the Person ID from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the person id from.
+   * @return The person id.
+   */
+  private String getPersonId(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PERSON_ID);
+  }
+
+  /**
+   * Get the Programme Membership Type from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the membership type from.
+   * @return The programme membership type.
+   */
+  private String getProgrammeMembershipType(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PROGRAMME_MEMBERSHIP_TYPE);
+  }
+
+  /**
+   * Get the Programme Start Date from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the start date from.
+   * @return The programme start date.
+   */
+  private String getProgrammeStartDate(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PROGRAMME_START_DATE);
+  }
+
+  /**
+   * Get the Programme End Date from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the end date from.
+   * @return The programme end date.
+   */
+  private String getProgrammeEndDate(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PROGRAMME_END_DATE);
+  }
+
+  /**
+   * Get the Programme Completion Date from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the membership type from.
+   * @return The programme membership type.
+   */
+  private String getProgrammeCompletionDate(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_PROGRAMME_COMPLETION_DATE);
+  }
+
+  /**
+   * Get the Curriculum ID from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the curriculum id from.
+   * @return The programme id.
+   */
+  private String getCurriculumId(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_CURRICULUM_ID);
+  }
+
+  /**
+   * Get the Curricula from the curriculumMembership.
+   *
+   * @param curriculumMembership The curriculumMembership to get the curricula from.
+   * @return The curricula.
+   */
+  private Set<Map<String, String>> getCurricula(CurriculumMembership curriculumMembership) {
+    ObjectMapper mapper = new ObjectMapper();
+
+    Set<Map<String, String>> curricula = new HashSet<>();
+    String curriculaString = curriculumMembership.getData().get(CURRICULUM_MEMBERSHIP_CURRICULA);
+    if (curriculaString != null) {
+      try {
+        curricula = mapper.readValue(curriculaString, new TypeReference<>() {
+        });
+      } catch (JsonProcessingException e) {
+        log.error("Badly formed curricula JSON in {}", curriculumMembership);
+      }
+    }
+
+    return curricula;
+  }
+
+  /**
+   * Get the Curricula JSON from the curricula string.
+   *
+   * @param curricula The curricula to convert to JSON.
+   * @return The curricula as JSON.
+   */
+  private String getCurriculaJson(Set<Map<String, String>> curricula) {
+    ObjectMapper mapper = new ObjectMapper();
+    String curriculaJson = "[]";
+    try {
+      curriculaJson = mapper.writeValueAsString(curricula);
+    } catch (Exception e) {
+      return null;
+    }
+    return curriculaJson;
+  }
+
+  /**
+   * Get the Name for the curriculum.
+   *
+   * @param curriculum The curriculum to get the name from.
+   * @return The curriculum name.
+   */
+  private String getCurriculumName(Curriculum curriculum) {
+    return curriculum.getData().get(CURRICULUM_NAME);
+  }
+
+  /**
+   * Get the SubType for the curriculum.
+   *
+   * @param curriculum The curriculum to get the subtype from.
+   * @return The curriculum subtype.
+   */
+  private String getCurriculumSubType(Curriculum curriculum) {
+    return curriculum.getData().get(CURRICULUM_SUB_TYPE);
+  }
+
+  /**
+   * Get the StartingDate for the curriculum.
+   * Note: this is taken from the curriculumMembership, NOT the curriculum.
+   * @param curriculumMembership The CurriculumMembership to get the starting date from.
+   * @return The curriculum starting date.
+   */
+  private String getCurriculumStartDate(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_START_DATE);
+  }
+
+  /**
+   * Get the EndDate for the curriculum.
+   *
+   * @param curriculumMembership The CurriculumMembership to get the curriculum end date from.
+   * @return The curriculum end date.
+   *
+   *                            Note: this is taken from the curriculumMembership, NOT the curriculum
+   */
+  private String getCurriculumEndDate(CurriculumMembership curriculumMembership) {
+    return curriculumMembership.getData().get(CURRICULUM_END_DATE);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
@@ -409,11 +409,11 @@ public class CurriculumMembershipEnricherFacade {
     //curricula
     Set<Map<String, String>> allCurricula = getCurricula(curriculumMembership);
 
-    // it is possible for the similar programmeMemberships to reference data (e.g. curricula)
+    // it is possible for the similar curriculumMemberships to reference data (e.g. curricula)
     // we do not yet have in the local store, in which case the sync will be aborted
     boolean doSync = true;
 
-    // traverse the similar programmeMemberships to derive the aggregate properties
+    // traverse the similar curriculumMemberships to derive the aggregate properties
     for (CurriculumMembership thisCurriculumMembership : curriculumMemberships) {
 
       // TIS ID

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacade.java
@@ -40,8 +40,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
-import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
@@ -90,7 +90,8 @@ public class CurriculumMembershipEnricherFacade {
 
   private final TcsSyncService tcsSyncService;
 
-  CurriculumMembershipEnricherFacade(CurriculumMembershipSyncService curriculumMembershipSyncService,
+  CurriculumMembershipEnricherFacade(
+                                    CurriculumMembershipSyncService curriculumMembershipSyncService,
                                     ProgrammeSyncService programmeSyncService,
                                     CurriculumSyncService curriculumSyncService,
                                     TcsSyncService tcsSyncService) {
@@ -183,8 +184,9 @@ public class CurriculumMembershipEnricherFacade {
   }
 
   /**
-   * Sync an enriched curriculumMembership with the curriculumMembership. Optionally enrich programme
-   * or curriculum details. Optionally completely resync all programme memberships for the person
+   * Sync an enriched curriculumMembership with the curriculumMembership. Optionally enrich
+   * programme or curriculum details. Optionally completely resync all programme memberships for
+   * the person.
    *
    * @param curriculumMembership                 The curriculumMembership to enrich.
    * @param doProgrammeEnrich                    Enrich programme details
@@ -296,7 +298,8 @@ public class CurriculumMembershipEnricherFacade {
           .add(getCurriculumMembershipsSimilarKey(aggregateCurriculumMembership));
 
       Set<CurriculumMembership> allTheirCurriculumMemberships =
-          curriculumMembershipSyncService.findByPersonId(getPersonId(aggregateCurriculumMembership));
+          curriculumMembershipSyncService
+              .findByPersonId(getPersonId(aggregateCurriculumMembership));
 
       for (CurriculumMembership theirCurriculumMembership : allTheirCurriculumMemberships) {
         if (!curriculumMembershipsSynced
@@ -475,7 +478,7 @@ public class CurriculumMembershipEnricherFacade {
     curriculumMembership.setOperation(DELETE);
     curriculumMembership.setSchema("tcs");
     curriculumMembership.setTable("CurriculumMembership");
-    tcsSyncService.syncRecord(curriculumMembership); // delete all curriculum memberships for personId
+    tcsSyncService.syncRecord(curriculumMembership); //delete all curriculummemberships for personId
   }
 
   /**
@@ -486,8 +489,9 @@ public class CurriculumMembershipEnricherFacade {
    * @param curriculumMembership The curriculum membership to retrieve the completion date from.
    * @return The new maximum date.
    */
-  private LocalDate getNewMaximumProgrammeCompletionDate(LocalDate currentMaximumDate,
-                                                         CurriculumMembership curriculumMembership) {
+  private LocalDate getNewMaximumProgrammeCompletionDate(
+                                                        LocalDate currentMaximumDate,
+                                                        CurriculumMembership curriculumMembership) {
     LocalDate newMaximumDate = currentMaximumDate;
     String programmeCompletionDateString = getProgrammeCompletionDate(curriculumMembership);
     if (programmeCompletionDateString != null) {
@@ -514,8 +518,8 @@ public class CurriculumMembershipEnricherFacade {
     String programmeStartDate = getProgrammeStartDate(curriculumMembership);
     String programmeEndDate = getProgrammeEndDate(curriculumMembership);
 
-    return curriculumMembershipSyncService.findBySimilar(personId, programmeId, programmeMembershipType,
-        programmeStartDate, programmeEndDate);
+    return curriculumMembershipSyncService.findBySimilar(personId, programmeId,
+        programmeMembershipType, programmeStartDate, programmeEndDate);
   }
 
   /**
@@ -721,7 +725,7 @@ public class CurriculumMembershipEnricherFacade {
    * @param curriculumMembership The CurriculumMembership to get the curriculum end date from.
    * @return The curriculum end date.
    *
-   *                            Note: this is taken from the curriculumMembership, NOT the curriculum
+   *                         Note: this is taken from the curriculumMembership, NOT the curriculum
    */
   private String getCurriculumEndDate(CurriculumMembership curriculumMembership) {
     return curriculumMembership.getData().get(CURRICULUM_END_DATE);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
@@ -32,8 +32,4 @@ public class CurriculumMembership extends Record {
 
   public static final String ENTITY_NAME = "CurriculumMembership";
 
-  //TODO: add toProgrammeMembership() method?
-  public ProgrammeMembership toProgrammeMembership() {
-
-  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.model;
+
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component(CurriculumMembership.ENTITY_NAME)
+@Scope(SCOPE_PROTOTYPE)
+public class CurriculumMembership extends Record {
+
+  public static final String ENTITY_NAME = "CurriculumMembership";
+
+  //TODO: add toProgrammeMembership() method?
+  public ProgrammeMembership toProgrammeMembership() {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/CurriculumMembershipRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/CurriculumMembershipRepository.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.repository;
+
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+
+@CacheConfig(cacheNames = CurriculumMembership.ENTITY_NAME)
+@Repository
+public interface CurriculumMembershipRepository
+    extends MongoRepository<CurriculumMembership, String> {
+
+  @Cacheable
+  @Override
+  Optional<CurriculumMembership> findById(String id);
+
+  @CachePut(key = "#entity.tisId")
+  @Override
+  <T extends CurriculumMembership> T save(T entity);
+
+  @CacheEvict
+  @Override
+  void deleteById(String id);
+
+  @Query("{ 'data.programmeId' : ?0}")
+  Set<CurriculumMembership> findByProgrammeId(String programmeId);
+
+  @Query("{ 'data.curriculumId' : ?0}")
+  Set<CurriculumMembership> findByCurriculumId(String curriculumId);
+
+  @Query("{ 'data.personId' : ?0}")
+  Set<CurriculumMembership> findByPersonId(String personId);
+
+  @Query("{ $and: [ { 'data.personId' : ?0}, { 'data.programmeId' : ?1 }, "
+      + "{ 'data.programmeMembershipType' : ?2}, { 'data.programmeStartDate' : ?3}, "
+      + "{ 'data.programmeEndDate' : ?4} ] }")
+  Set<CurriculumMembership> findBySimilar(String personId,
+                                         String programmeId, String programmeMembershipType,
+                                         String programmeStartDate, String programmeEndDate);
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncService.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.CurriculumMembershipRepository;
+
+@Slf4j
+@Service("tcs-CurriculumMembership")
+public class CurriculumMembershipSyncService implements SyncService {
+
+  private final CurriculumMembershipRepository repository;
+
+  private final DataRequestService dataRequestService;
+
+  private final Set<String> requestedIds = new HashSet<>();
+
+  CurriculumMembershipSyncService(CurriculumMembershipRepository repository,
+                                 DataRequestService dataRequestService) {
+    this.repository = repository;
+    this.dataRequestService = dataRequestService;
+  }
+
+  @Override
+  public void syncRecord(Record curriculumMembership) {
+    if (!(curriculumMembership instanceof CurriculumMembership)) {
+      String message = String.format("Invalid record type '%s'.", curriculumMembership.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    if (curriculumMembership.getOperation().equals(DELETE)) {
+      repository.deleteById(curriculumMembership.getTisId());
+    } else {
+      repository.save((CurriculumMembership) curriculumMembership);
+    }
+
+    String id = curriculumMembership.getTisId();
+    requestedIds.remove(id);
+  }
+
+  public Optional<CurriculumMembership> findById(String id) {
+    return repository.findById(id);
+  }
+
+  public Set<CurriculumMembership> findByProgrammeId(String programmeId) {
+    return repository.findByProgrammeId(programmeId);
+  }
+
+  public Set<CurriculumMembership> findByCurriculumId(String curriculumId) {
+    return repository.findByCurriculumId(curriculumId);
+  }
+
+  public Set<CurriculumMembership> findByPersonId(String personId) {
+    return repository.findByPersonId(personId);
+  }
+
+  public Set<CurriculumMembership> findBySimilar(String personId,
+                                                String programmeId,
+                                                String programmeMembershipType,
+                                                String programmeStartDate,
+                                                String programmeEndDate) {
+    return repository.findBySimilar(personId, programmeId, programmeMembershipType,
+        programmeStartDate, programmeEndDate);
+  }
+
+  /**
+   * Make a request to retrieve a specific Curriculum Membership.
+   *
+   * @param id The id of the Curriculum Membership to be retrieved.
+   */
+  public void request(String id) {
+    if (!requestedIds.contains(id)) {
+      log.info("Sending request for ProgrammeMembership [{}]", id);
+
+      try {
+        dataRequestService.sendRequest(CurriculumMembership.ENTITY_NAME, Map.of("id", id));
+        requestedIds.add(id);
+      } catch (JsonProcessingException e) {
+        log.error("Error while trying to request a CurriculumMembership", e);
+      }
+    } else {
+      log.debug("Already requested CurriculumMembership [{}].", id);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncService.java
@@ -99,7 +99,7 @@ public class CurriculumMembershipSyncService implements SyncService {
    */
   public void request(String id) {
     if (!requestedIds.contains(id)) {
-      log.info("Sending request for ProgrammeMembership [{}]", id);
+      log.info("Sending request for CurriculumMembership [{}]", id);
 
       try {
         dataRequestService.sendRequest(CurriculumMembership.ENTITY_NAME, Map.of("id", id));

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
@@ -57,9 +57,10 @@ public class RecordService {
           recrd.getSchema(), recrd.getTable());
       return;
     }
-    if (recrd.getSchema().equals("tcs") && recrd.getTable().equals("ProgrammeMembership")) {
-      log.info("Skipping tcs.ProgrammeMembership record with operation '{}'.",
-          recrd.getOperation());
+    if (recrd.getSchema().equals("tcs")
+        && recrd.getTable().equals(ProgrammeMembership.ENTITY_NAME)) {
+      log.info("Skipping deprecated record with operation '{}' on '{}.{}'.", recrd.getOperation(),
+          recrd.getSchema(), recrd.getTable());
       return;
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.dto.RecordDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.RecordMapper;
+import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.model.RecordType;
 
@@ -54,6 +55,11 @@ public class RecordService {
     if (recrd.getType().equals(RecordType.CONTROL)) {
       log.info("Skipping non-data record with operation '{}' on '{}.{}'.", recrd.getOperation(),
           recrd.getSchema(), recrd.getTable());
+      return;
+    }
+    if (recrd.getSchema().equals("tcs") && recrd.getTable().equals("ProgrammeMembership")) {
+      log.info("Skipping tcs.ProgrammeMembership record with operation '{}'.",
+          recrd.getOperation());
       return;
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -67,8 +67,8 @@ public class TcsSyncService implements SyncService {
       Map.entry(TABLE_QUALIFICATION, "qualification"),
       Map.entry(TABLE_PLACEMENT, "placement"),
       Map.entry(TABLE_PROGRAMME_MEMBERSHIP, "programme-membership"),
-      Map.entry(TABLE_CURRICULUM_MEMBERSHIP, "curriculum-membership"),
-      //write to new table since we'll need to rebuild programme-membership table
+      Map.entry(TABLE_CURRICULUM_MEMBERSHIP, "programme-membership"),
+      //use same trainee-details API endpoint
       Map.entry(TABLE_CURRICULUM, "curriculum")
   );
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -54,6 +54,7 @@ public class TcsSyncService implements SyncService {
   private static final String TABLE_QUALIFICATION = "Qualification";
   private static final String TABLE_PLACEMENT = "Placement";
   private static final String TABLE_PROGRAMME_MEMBERSHIP = "ProgrammeMembership";
+  private static final String TABLE_CURRICULUM_MEMBERSHIP = "CurriculumMembership";
   private static final String TABLE_CURRICULUM = "Curriculum";
 
   private static final Map<String, String> TABLE_NAME_TO_API_PATH = Map.ofEntries(
@@ -66,6 +67,7 @@ public class TcsSyncService implements SyncService {
       Map.entry(TABLE_QUALIFICATION, "qualification"),
       Map.entry(TABLE_PLACEMENT, "placement"),
       Map.entry(TABLE_PROGRAMME_MEMBERSHIP, "programme-membership"),
+      Map.entry(TABLE_CURRICULUM_MEMBERSHIP, "curriculum-membership"), //write to new table since we'll need to rebuild programme-membership table
       Map.entry(TABLE_CURRICULUM, "curriculum")
   );
 
@@ -95,6 +97,7 @@ public class TcsSyncService implements SyncService {
         Map.entry(TABLE_QUALIFICATION, mapper::toQualificationDto),
         Map.entry(TABLE_PLACEMENT, mapper::toPlacementDto),
         Map.entry(TABLE_PROGRAMME_MEMBERSHIP, mapper::toProgrammeMembershipDto),
+        Map.entry(TABLE_CURRICULUM_MEMBERSHIP, mapper::toProgrammeMembershipDto), //use same DTO
         Map.entry(TABLE_CURRICULUM, mapper::toCurriculumDto)
     );
   }
@@ -150,7 +153,8 @@ public class TcsSyncService implements SyncService {
             dto.getTraineeTisId());
         break;
       case DELETE:
-        if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PROGRAMME_MEMBERSHIP))) {
+        if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PROGRAMME_MEMBERSHIP)) ||
+            apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_CURRICULUM_MEMBERSHIP))) {
           restTemplate.delete(serviceUrl + API_ID_TEMPLATE, apiPath, dto.getTraineeTisId());
         } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PLACEMENT)) ||
             apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_QUALIFICATION))) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -67,7 +67,8 @@ public class TcsSyncService implements SyncService {
       Map.entry(TABLE_QUALIFICATION, "qualification"),
       Map.entry(TABLE_PLACEMENT, "placement"),
       Map.entry(TABLE_PROGRAMME_MEMBERSHIP, "programme-membership"),
-      Map.entry(TABLE_CURRICULUM_MEMBERSHIP, "curriculum-membership"), //write to new table since we'll need to rebuild programme-membership table
+      Map.entry(TABLE_CURRICULUM_MEMBERSHIP, "curriculum-membership"),
+      //write to new table since we'll need to rebuild programme-membership table
       Map.entry(TABLE_CURRICULUM, "curriculum")
   );
 
@@ -153,8 +154,8 @@ public class TcsSyncService implements SyncService {
             dto.getTraineeTisId());
         break;
       case DELETE:
-        if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PROGRAMME_MEMBERSHIP)) ||
-            apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_CURRICULUM_MEMBERSHIP))) {
+        if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PROGRAMME_MEMBERSHIP))
+            || apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_CURRICULUM_MEMBERSHIP))) {
           restTemplate.delete(serviceUrl + API_ID_TEMPLATE, apiPath, dto.getTraineeTisId());
         } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PLACEMENT)) ||
             apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_QUALIFICATION))) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingCurriculumMembershipIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingCurriculumMembershipIntTest.java
@@ -1,0 +1,171 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import io.awspring.cloud.autoconfigure.messaging.SqsAutoConfiguration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.annotation.DirtiesContext;
+import uk.nhs.hee.tis.trainee.sync.config.MongoConfiguration;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.repository.CurriculumMembershipRepository;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+
+@SpringBootTest(properties = { "cloud.aws.region.static=eu-west-2" })
+@EnableAutoConfiguration(exclude = SqsAutoConfiguration.class)
+@DirtiesContext(classMode = AFTER_EACH_TEST_METHOD)
+class CachingCurriculumMembershipIntTest {
+
+  private static final String CURRICULUM_MEMBERSHIP_FORDY = "fordy";
+
+  // We require access to the mock before the proxy wraps it.
+  private static CurriculumMembershipRepository mockCurriculumMembershipRepository;
+
+  @MockBean
+  private AmazonSQSAsync amazonSqsAsync;
+
+  @Autowired
+  CurriculumMembershipSyncService curriculumMembershipSyncService;
+
+  @Autowired
+  CacheManager cacheManager;
+
+  private Cache curriculumMembershipCache;
+
+  private CurriculumMembership curriculumMembership;
+
+  @BeforeEach
+  void setup() {
+    curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_FORDY);
+    curriculumMembership.setOperation(Operation.DELETE);
+    curriculumMembership.setTable(CurriculumMembership.ENTITY_NAME);
+
+    curriculumMembershipCache = cacheManager.getCache(CurriculumMembership.ENTITY_NAME);
+  }
+
+  @Test
+  void shouldHitCacheOnSecondInvocation() {
+    when(mockCurriculumMembershipRepository.findById(CURRICULUM_MEMBERSHIP_FORDY))
+        .thenReturn(Optional.of(curriculumMembership), Optional.of(new CurriculumMembership()));
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY)).isNull();
+
+    Optional<CurriculumMembership> actual1 =
+        curriculumMembershipSyncService.findById(CURRICULUM_MEMBERSHIP_FORDY);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY)).isNotNull();
+    Optional<CurriculumMembership> actual2 =
+        curriculumMembershipSyncService.findById(CURRICULUM_MEMBERSHIP_FORDY);
+
+    verify(mockCurriculumMembershipRepository).findById(CURRICULUM_MEMBERSHIP_FORDY);
+    assertThat(actual1).isPresent().get()
+        .isEqualTo(curriculumMembership)
+        .isEqualTo(actual2.orElseThrow());
+  }
+
+  @Test
+  void shouldEvictWhenDeletedAndMissCacheOnNextInvocation() {
+    CurriculumMembership otherCurriculumMembership = new CurriculumMembership();
+    final String otherKey = "Foo";
+    otherCurriculumMembership.setTisId(otherKey);
+    otherCurriculumMembership.setOperation(Operation.LOAD);
+    when(mockCurriculumMembershipRepository.findById(otherKey))
+        .thenReturn(Optional.of(otherCurriculumMembership));
+    curriculumMembershipSyncService.findById(otherKey);
+    assertThat(curriculumMembershipCache.get(otherKey)).isNotNull();
+    when(mockCurriculumMembershipRepository.findById(CURRICULUM_MEMBERSHIP_FORDY))
+        .thenReturn(Optional.of(curriculumMembership));
+    curriculumMembershipSyncService.findById(CURRICULUM_MEMBERSHIP_FORDY);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY)).isNotNull();
+
+    curriculumMembershipSyncService.syncRecord(curriculumMembership);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY)).isNull();
+    assertThat(curriculumMembershipCache.get(otherKey)).isNotNull();
+    verify(mockCurriculumMembershipRepository).deleteById(CURRICULUM_MEMBERSHIP_FORDY);
+
+    curriculumMembershipSyncService.findById(CURRICULUM_MEMBERSHIP_FORDY);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY)).isNotNull();
+
+    verify(mockCurriculumMembershipRepository, times(2))
+        .findById(CURRICULUM_MEMBERSHIP_FORDY);
+  }
+
+  @Test
+  void shouldReplaceCacheWhenSaved() {
+    CurriculumMembership staleCurriculumMembership = new CurriculumMembership();
+    staleCurriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_FORDY);
+    staleCurriculumMembership.setTable("Stale");
+    staleCurriculumMembership.setOperation(Operation.UPDATE);
+    when(mockCurriculumMembershipRepository.save(staleCurriculumMembership))
+        .thenReturn(staleCurriculumMembership);
+    curriculumMembershipSyncService.syncRecord(staleCurriculumMembership);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY).get())
+        .isEqualTo(staleCurriculumMembership);
+
+    CurriculumMembership updateCurriculumMembership = new CurriculumMembership();
+    updateCurriculumMembership.setTable(CurriculumMembership.ENTITY_NAME);
+    updateCurriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_FORDY);
+    updateCurriculumMembership.setOperation(Operation.UPDATE);
+    when(mockCurriculumMembershipRepository.save(updateCurriculumMembership))
+        .thenReturn(curriculumMembership);
+
+    curriculumMembershipSyncService.syncRecord(updateCurriculumMembership);
+    assertThat(curriculumMembershipCache.get(CURRICULUM_MEMBERSHIP_FORDY).get())
+        .isEqualTo(curriculumMembership);
+    verify(mockCurriculumMembershipRepository).save(staleCurriculumMembership);
+    verify(mockCurriculumMembershipRepository).save(updateCurriculumMembership);
+  }
+
+  @TestConfiguration
+  static class Configuration {
+
+    @Primary
+    @Bean
+    CurriculumMembershipRepository mockCurriculumMembershipRepository() {
+      mockCurriculumMembershipRepository = mock(CurriculumMembershipRepository.class);
+      return mockCurriculumMembershipRepository;
+    }
+
+    ////// Mocks to enable application context //////
+    @MockBean
+    private MongoConfiguration mongoConfiguration;
+    /////////////////////////////////////////////////
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 
 class CurriculumEventListenerTest {
@@ -39,13 +39,13 @@ class CurriculumEventListenerTest {
   private static final String TIS_ID = "5";
 
   private CurriculumEventListener listener;
-  private ProgrammeMembershipEnricherFacade enricher;
+  private CurriculumMembershipEnricherFacade enricher;
   private CacheManager cacheManager;
   private Cache cache;
 
   @BeforeEach
   void setUp() {
-    enricher = mock(ProgrammeMembershipEnricherFacade.class);
+    enricher = mock(CurriculumMembershipEnricherFacade.class);
     cacheManager = mock(CacheManager.class);
     cache = mock(Cache.class);
     when(cacheManager.getCache(Curriculum.ENTITY_NAME)).thenReturn(cache);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
@@ -117,7 +117,8 @@ class CurriculumMembershipEventListenerTest {
     Document document = new Document();
     document.append("_id", "1");
     CurriculumMembership curriculumMembership = new CurriculumMembership();
-    AfterDeleteEvent<CurriculumMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
+    AfterDeleteEvent<CurriculumMembership> eventAfter
+        = new AfterDeleteEvent<>(document, null, null);
 
     when(mockCache.get("1", CurriculumMembership.class)).thenReturn(curriculumMembership);
 
@@ -131,7 +132,8 @@ class CurriculumMembershipEventListenerTest {
   void shouldNotCallFacadeDeleteIfNoProgrammeMembership() {
     Document document = new Document();
     document.append("_id", "1");
-    AfterDeleteEvent<CurriculumMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
+    AfterDeleteEvent<CurriculumMembership> eventAfter
+        = new AfterDeleteEvent<>(document, null, null);
 
     when(mockCache.get("1", CurriculumMembership.class)).thenReturn(null);
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
+
+class CurriculumMembershipEventListenerTest {
+
+  private CurriculumMembershipEventListener listener;
+
+  private CurriculumMembershipEnricherFacade mockEnricher;
+
+  private CurriculumMembershipSyncService mockCurriculumMembershipSyncService;
+
+  CacheManager mockCacheManager;
+
+  Cache mockCache;
+
+  @BeforeEach
+  void setUp() {
+    mockEnricher = mock(CurriculumMembershipEnricherFacade.class);
+    mockCurriculumMembershipSyncService = mock(CurriculumMembershipSyncService.class);
+    mockCacheManager = mock(CacheManager.class);
+    mockCache = mock(Cache.class);
+
+    when(mockCacheManager.getCache(anyString())).thenReturn(mockCache);
+    listener = new CurriculumMembershipEventListener(mockEnricher,
+        mockCurriculumMembershipSyncService, mockCacheManager);
+  }
+
+  @Test
+  void shouldCallEnricherAfterSave() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    AfterSaveEvent<CurriculumMembership> event = new AfterSaveEvent<>(curriculumMembership, null,
+        null);
+
+    listener.onAfterSave(event);
+
+    verify(mockEnricher).enrich(curriculumMembership);
+    verifyNoMoreInteractions(mockEnricher);
+  }
+
+  @Test
+  void shouldFindAndCacheProgrammeMembershipIfNotInCacheBeforeDelete() {
+    Document document = new Document();
+    document.append("_id", "1");
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    BeforeDeleteEvent<CurriculumMembership> event = new BeforeDeleteEvent<>(document, null, null);
+
+    when(mockCache.get("1", CurriculumMembership.class)).thenReturn(null);
+    when(mockCurriculumMembershipSyncService.findById(anyString()))
+        .thenReturn(Optional.of(curriculumMembership));
+
+    listener.onBeforeDelete(event);
+
+    verify(mockCurriculumMembershipSyncService).findById("1");
+    verify(mockCache).put("1", curriculumMembership);
+    verifyNoMoreInteractions(mockEnricher);
+  }
+
+  @Test
+  void shouldNotFindAndCacheProgrammeMembershipIfInCacheBeforeDelete() {
+    Document document = new Document();
+    document.append("_id", "1");
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    BeforeDeleteEvent<CurriculumMembership> event = new BeforeDeleteEvent<>(document, null, null);
+
+    when(mockCache.get("1", CurriculumMembership.class)).thenReturn(curriculumMembership);
+
+    listener.onBeforeDelete(event);
+
+    verifyNoInteractions(mockCurriculumMembershipSyncService);
+    verifyNoMoreInteractions(mockEnricher);
+  }
+
+  @Test
+  void shouldCallFacadeDeleteAfterDelete() {
+    Document document = new Document();
+    document.append("_id", "1");
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    AfterDeleteEvent<CurriculumMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
+
+    when(mockCache.get("1", CurriculumMembership.class)).thenReturn(curriculumMembership);
+
+    listener.onAfterDelete(eventAfter);
+
+    verify(mockEnricher).delete(curriculumMembership);
+    verifyNoMoreInteractions(mockEnricher);
+  }
+
+  @Test
+  void shouldNotCallFacadeDeleteIfNoProgrammeMembership() {
+    Document document = new Document();
+    document.append("_id", "1");
+    AfterDeleteEvent<CurriculumMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
+
+    when(mockCache.get("1", CurriculumMembership.class)).thenReturn(null);
+
+    listener.onAfterDelete(eventAfter);
+
+    verifyNoInteractions(mockEnricher);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
@@ -28,17 +28,17 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
+import uk.nhs.hee.tis.trainee.sync.facade.CurriculumMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 
 class ProgrammeEventListenerTest {
 
   private ProgrammeEventListener listener;
-  private ProgrammeMembershipEnricherFacade enricher;
+  private CurriculumMembershipEnricherFacade enricher;
 
   @BeforeEach
   void setUp() {
-    enricher = mock(ProgrammeMembershipEnricherFacade.class);
+    enricher = mock(CurriculumMembershipEnricherFacade.class);
     listener = new ProgrammeEventListener(enricher);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacadeTest.java
@@ -48,10 +48,10 @@ import org.mockito.Spy;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
-import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.service.CurriculumSyncService;
+import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.TcsSyncService;
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/CurriculumMembershipEnricherFacadeTest.java
@@ -1,0 +1,885 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.facade;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.internal.util.collections.Sets;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
+import uk.nhs.hee.tis.trainee.sync.model.Programme;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.TcsSyncService;
+
+@ExtendWith(MockitoExtension.class)
+class CurriculumMembershipEnricherFacadeTest {
+
+  private static final String CURRICULUM_MEMBERSHIP_A11_TIS_ID = "11";
+  private static final String CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID = "programme1";
+  private static final String CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID = "curriculum1";
+  private static final String CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE = "2020-01-31";
+
+  private static final String CURRICULUM_MEMBERSHIP_A12_TIS_ID = "12";
+  private static final String CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID = "programme1";
+  private static final String CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID = "curriculum2";
+  private static final String CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE = "2020-06-30";
+
+  private static final String CURRICULUM_MEMBERSHIP_A32_TIS_ID = "32";
+  private static final String CURRICULUM_MEMBERSHIP_A32_PROGRAMME_ID = "programme3";
+  private static final String CURRICULUM_MEMBERSHIP_A32_CURRICULUM_ID = "curriculum2";
+  private static final String CURRICULUM_MEMBERSHIP_A32_PROGRAMME_COMPLETION_DATE = "2020-06-30";
+
+  private static final String PROGRAMME_1_ID = "programme1";
+  private static final String PROGRAMME_1_NAME = "programme One";
+  private static final String PROGRAMME_1_NAME_UPDATED = "programme One updated";
+  private static final String PROGRAMME_1_NUMBER = "programme No. One";
+  private static final String PROGRAMME_1_OWNER = "programme One owner";
+  private static final String PROGRAMME_3_ID = "programme3";
+  private static final String PROGRAMME_3_NAME = "programme Three";
+  private static final String CURRICULUM_1_ID = "curriculum1";
+  private static final String CURRICULUM_1_NAME = "curriculum One";
+  private static final String CURRICULUM_1_START_DATE = "2020-01-01";
+  private static final String CURRICULUM_1_END_DATE = "2021-01-01";
+  private static final String CURRICULUM_2_ID = "curriculum2";
+  private static final String CURRICULUM_2_NAME = "curriculum Two";
+  private static final String CURRICULUM_2_NAME_UPDATED = "curriculum Two updated";
+  private static final String ALL_TIS_ID = "1";
+  private static final String ALL_PERSON_ID = "personA";
+  private static final String ALL_PROGRAMME_COMPLETION_DATE = "2020-02-01";
+  private static final String ALL_CURRICULUM_MEMBERSHIP_TYPE = "SUBSTANTIVE";
+  private static final String ALL_PROGRAMME_START_DATE = "2020-01-01";
+  private static final String ALL_PROGRAMME_END_DATE = "2021-01-01";
+
+  //fields in curriculum/programme sync repo documents
+  private static final String CURRICULUM_NAME = "name";
+  private static final String PROGRAMME_NAME = "programmeName";
+  private static final String PROGRAMME_NUMBER = "programmeNumber";
+  private static final String PROGRAMME_OWNER = "owner";
+
+  // fields in curriculumMembership sync repo documents
+  private static final String DATA_TIS_ID = "tisId";
+  private static final String DATA_PROGRAMME_ID = "programmeId";
+  private static final String DATA_CURRICULUM_ID = "curriculumId";
+  private static final String DATA_PERSON_ID = "personId";
+  private static final String DATA_CURRICULUM_MEMBERSHIP_TYPE = "programmeMembershipType";
+  private static final String DATA_PROGRAMME_END_DATE = "programmeEndDate";
+  private static final String DATA_PROGRAMME_START_DATE = "programmeStartDate";
+  private static final String DATA_PROGRAMME_COMPLETION_DATE = "programmeCompletionDate";
+  private static final String DATA_CURRICULUM_START_DATE = "curriculumStartDate";
+  private static final String DATA_CURRICULUM_END_DATE = "curriculumEndDate";
+  private static final String DATA_PROGRAMME_NUMBER = "programmeNumber";
+  private static final String DATA_MANAGING_DEANERY = "managingDeanery";
+
+  // processed fields in curriculumMembership DTO passed to trainee-details for persisting
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME = "programmeName";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NUMBER = "programmeNumber";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_MANAGING_DEANERY = "managingDeanery";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_CURRICULA = "curricula";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_NAME = "curriculumName";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_START_DATE
+      = "curriculumStartDate";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_END_DATE
+      = "curriculumEndDate";
+  private static final String CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_COMPLETION_DATE =
+      "programmeCompletionDate";
+
+  @InjectMocks
+  @Spy
+  private CurriculumMembershipEnricherFacade enricher;
+
+  @Mock
+  private CurriculumMembershipSyncService curriculumMembershipService;
+
+  @Mock
+  private ProgrammeSyncService programmeService;
+
+  @Mock
+  private CurriculumSyncService curriculumService;
+
+  @Mock
+  private TcsSyncService tcsSyncService;
+
+  @Test
+  void shouldEnrichFromCurriculumMembershipWhenProgrammeAndCurriculumExist() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, ALL_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, PROGRAMME_1_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_1_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_CURRICULUM_START_DATE, CURRICULUM_1_START_DATE,
+        DATA_CURRICULUM_END_DATE, CURRICULUM_1_END_DATE)));
+    curriculumMembership.setTisId(ALL_TIS_ID);
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME,
+        PROGRAMME_NUMBER, PROGRAMME_1_NUMBER,
+        PROGRAMME_OWNER, PROGRAMME_1_OWNER
+    ));
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(CURRICULUM_1_ID);
+    curriculum.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme));
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(java.util.Collections.singleton(curriculumMembership));
+
+    enricher.enrich(curriculumMembership);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService, never()).request(anyString());
+
+    tcsSyncService.syncRecord(curriculumMembership);
+
+    Map<String, String> curriculumMembershipData = curriculumMembership.getData();
+    assertThat("Unexpected programme name.",
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME),
+        is(PROGRAMME_1_NAME));
+    assertThat("Unexpected programme number.",
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NUMBER),
+        is(PROGRAMME_1_NUMBER));
+    assertThat("Unexpected managing deanery.",
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_MANAGING_DEANERY),
+        is(PROGRAMME_1_OWNER));
+    Set<Map<String, String>> curriculumMembershipCurricula = getCurriculaFromJson(
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULA));
+    assertThat("Unexpected curricula size.", curriculumMembershipCurricula.size(),
+        is(1));
+    Map<String, String> curriculumData = curriculumMembershipCurricula.iterator().next();
+    assertThat("Unexpected curriculum name.",
+        curriculumData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_NAME),
+        is(CURRICULUM_1_NAME));
+    assertThat("Unexpected curriculum start date.",
+        curriculumData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_START_DATE),
+        is(CURRICULUM_1_START_DATE));
+    assertThat("Unexpected curriculum end date.",
+        curriculumData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_END_DATE),
+        is(CURRICULUM_1_END_DATE));
+  }
+
+  @Test
+  void shouldEnrichPmCurriculaAndProgrammeCompletionDateFromAllSimilarPms() {
+    // the programme membership to enrich
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, ALL_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, PROGRAMME_1_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_1_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, ALL_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership.setTisId(ALL_TIS_ID);
+
+    // similar programme memberships
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A12_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership2.setTisId(CURRICULUM_MEMBERSHIP_A12_TIS_ID);
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setTisId(CURRICULUM_1_ID);
+    curriculum1.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setTisId(CURRICULUM_2_ID);
+    curriculum2.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME
+    ));
+
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme));
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum1));
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.of(curriculum2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+
+    enricher.enrich(curriculumMembership);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService, never()).request(anyString());
+
+    tcsSyncService.syncRecord(curriculumMembership);
+
+    Map<String, String> curriculumMembershipData = curriculumMembership.getData();
+    assertThat("Unexpected programme name.",
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME),
+        is(PROGRAMME_1_NAME));
+    assertThat("Unexpected programme completion date.",
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_COMPLETION_DATE),
+        is(CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE));
+
+    Set<Map<String, String>> curriculumMembershipCurricula = getCurriculaFromJson(
+        curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULA));
+    assertThat("Unexpected curricula size.", curriculumMembershipCurricula.size(),
+        is(2)); // not 3, since curriculum 1 is represented twice
+
+    List<String> curriculaNames = curriculumMembershipCurricula.stream().map(curriculum ->
+        curriculum.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_NAME)).collect(Collectors.toList());
+    assertThat("Unexpected curriculum name.", curriculaNames.contains(CURRICULUM_1_NAME),
+        is(true));
+    assertThat("Unexpected curriculum name.", curriculaNames.contains(CURRICULUM_2_NAME),
+        is(true));
+  }
+
+  @Test
+  void shouldEnrichCurriculumMembershipsFromProgramme() {
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A12_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership2.setTisId(CURRICULUM_MEMBERSHIP_A12_TIS_ID);
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME_UPDATED
+    ));
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setTisId(CURRICULUM_1_ID);
+    curriculum1.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setTisId(CURRICULUM_2_ID);
+    curriculum2.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID))
+        .thenReturn(Optional.of(curriculum1));
+    when(curriculumService.findById(CURRICULUM_2_ID))
+        .thenReturn(Optional.of(curriculum2));
+    when(curriculumMembershipService.findByProgrammeId(PROGRAMME_1_ID))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+
+    enricher.enrich(programme);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService, never()).request(anyString());
+
+    tcsSyncService.syncRecord(curriculumMembership1);
+    tcsSyncService.syncRecord(curriculumMembership2);
+
+    Map<String, String> curriculumMembership1Data = curriculumMembership1.getData();
+    assertThat("Unexpected programme name.",
+        curriculumMembership1Data.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME),
+        is(PROGRAMME_1_NAME_UPDATED));
+    Map<String, String> curriculumMembership2Data = curriculumMembership2.getData();
+    assertThat("Unexpected programme name.",
+        curriculumMembership2Data.get(CURRICULUM_MEMBERSHIP_DATA_PROGRAMME_NAME),
+        is(PROGRAMME_1_NAME_UPDATED));
+  }
+
+  @Test
+  void shouldEnrichCurriculumMembershipsFromCurriculum() {
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A12_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A12_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A32_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A32_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A32_TIS_ID);
+
+    Programme programme1 = new Programme();
+    programme1.setTisId(PROGRAMME_1_ID);
+    programme1.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Programme programme3 = new Programme();
+    programme3.setTisId(PROGRAMME_3_ID);
+    programme3.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_3_NAME
+    ));
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(CURRICULUM_2_ID);
+    curriculum.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME_UPDATED
+    ));
+
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme1));
+    when(programmeService.findById(PROGRAMME_3_ID)).thenReturn(Optional.of(programme3));
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.of(curriculum));
+    when(curriculumMembershipService.findByCurriculumId(CURRICULUM_2_ID))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_3_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership2));
+
+    enricher.enrich(curriculum);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService, never()).request(anyString());
+
+    tcsSyncService.syncRecord(curriculumMembership1);
+    tcsSyncService.syncRecord(curriculumMembership2);
+
+    Map<String, String> curriculumMembership1Data = curriculumMembership1.getData();
+    Set<Map<String, String>> curriculumMembership1Curricula =
+        getCurriculaFromJson(curriculumMembership1Data.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULA));
+    assertThat("Unexpected curricula size.", curriculumMembership1Curricula.size(),
+        is(1));
+    assertThat("Unexpected curriculum name.",
+        curriculumMembership1Curricula.iterator().next()
+            .get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_NAME),
+        is(CURRICULUM_2_NAME_UPDATED));
+
+    Map<String, String> curriculumMembership2Data = curriculumMembership2.getData();
+    Set<Map<String, String>> curriculumMembership2Curricula =
+        getCurriculaFromJson(curriculumMembership2Data.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULA));
+    assertThat("Unexpected curricula size.", curriculumMembership2Curricula.size(),
+        is(1));
+    assertThat("Unexpected curriculum name.",
+        curriculumMembership2Curricula.iterator().next()
+            .get(CURRICULUM_MEMBERSHIP_DATA_CURRICULUM_NAME),
+        is(CURRICULUM_2_NAME_UPDATED));
+  }
+
+  @Test
+  void shouldNotEnrichFromCurriculumMembershipWhenCurriculumNotExist() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, ALL_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, PROGRAMME_1_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_1_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE)));
+    curriculumMembership.setTisId(ALL_TIS_ID);
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme));
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.empty());
+
+    enricher.enrich(curriculumMembership);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService).findById(PROGRAMME_1_ID);
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService).findById(CURRICULUM_1_ID);
+    verify(curriculumService).request(CURRICULUM_1_ID);
+
+    verifyNoInteractions(tcsSyncService);
+  }
+
+  @Test
+  void shouldNotEnrichFromCurriculumMembershipWhenProgrammeNotExist() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, ALL_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, PROGRAMME_1_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_1_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE)));
+    curriculumMembership.setTisId(ALL_TIS_ID);
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(CURRICULUM_1_ID);
+    curriculum.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.empty());
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum));
+
+    enricher.enrich(curriculumMembership);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService).findById(PROGRAMME_1_ID);
+    verify(programmeService).request(PROGRAMME_1_ID);
+    verify(curriculumService).findById(CURRICULUM_1_ID);
+    verify(curriculumService, never()).request(anyString());
+
+    verifyNoInteractions(tcsSyncService);
+  }
+
+  @Test
+  void shouldNotEnrichFromProgrammeWhenSomeCurriculaNotExist() {
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A12_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership2.setTisId(CURRICULUM_MEMBERSHIP_A12_TIS_ID);
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME_UPDATED
+    ));
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setTisId(CURRICULUM_1_ID);
+    curriculum1.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum1));
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.empty());
+    when(curriculumMembershipService.findByProgrammeId(PROGRAMME_1_ID))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+
+    enricher.enrich(programme);
+
+    verify(curriculumMembershipService, never()).request(anyString());
+    verify(programmeService, never()).request(anyString());
+    verify(curriculumService, times(2)).findById(CURRICULUM_1_ID);
+    verify(curriculumService, times(2)).findById(CURRICULUM_2_ID);
+    verify(curriculumService).request(CURRICULUM_2_ID); // should only request once
+
+    verifyNoInteractions(tcsSyncService);
+  }
+
+  @Test
+  void shouldDeletePersonsCurriculumMembershipsBeforeSyncingCurriculumMembership() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(CURRICULUM_1_ID);
+    curriculum.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum));
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme));
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Collections.singleton(curriculumMembership));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Collections.singleton(curriculumMembership));
+
+    enricher.enrich(curriculumMembership);
+
+    // the initial 'DELETE' and then 'LOAD' sync both use curriculumMembership
+    verify(tcsSyncService, times(2)).syncRecord(curriculumMembership);
+  }
+
+  @Test
+  void shouldNotDeletePersonsCurriculumMembershipsBeforeSyncingProgramme() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+
+    Programme programme = new Programme();
+    programme.setTisId(PROGRAMME_1_ID);
+    programme.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId(CURRICULUM_1_ID);
+    curriculum.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum));
+    when(curriculumMembershipService.findByProgrammeId(PROGRAMME_1_ID))
+        .thenReturn(Collections.singleton(curriculumMembership));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Collections.singleton(curriculumMembership));
+
+    enricher.enrich(programme);
+
+    // the initial 'DELETE' and then 'LOAD' sync would both use curriculumMembership
+    // we only want one invocation for 'LOAD'
+    verify(tcsSyncService).syncRecord(curriculumMembership);
+  }
+
+  @Test
+  void shouldSkipSimilarCurriculumMembershipsWhenReloadingPersonsCurriculumMemberships() {
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A12_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A12_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A12_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership2.setTisId(CURRICULUM_MEMBERSHIP_A12_TIS_ID);
+
+    Programme programme1 = new Programme();
+    programme1.setTisId(PROGRAMME_1_ID);
+    programme1.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setTisId(CURRICULUM_1_ID);
+    curriculum1.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setTisId(CURRICULUM_2_ID);
+    curriculum2.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum1));
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.of(curriculum2));
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme1));
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+
+    enricher.enrich(curriculumMembership1);
+    verify(enricher).syncAggregateCurriculumMembership(curriculumMembership1, true);
+    verify(enricher, never()).syncAggregateCurriculumMembership(curriculumMembership2, false);
+
+    // the initial 'DELETE' and then 'LOAD' sync both use curriculumMembership
+    verify(tcsSyncService, times(2)).syncRecord(curriculumMembership1);
+  }
+
+  @Test
+  void shouldNotSkipDisSimilarCurriculumMembershipsWhenReloadingPersonsCurriculumMemberships() {
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A11_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A11_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+    CurriculumMembership curriculumMembership2 = new CurriculumMembership();
+    curriculumMembership2.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A32_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A32_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership2.setTisId(CURRICULUM_MEMBERSHIP_A32_TIS_ID);
+
+    Programme programme1 = new Programme();
+    programme1.setTisId(PROGRAMME_1_ID);
+    programme1.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_1_NAME
+    ));
+    Programme programme3 = new Programme();
+    programme3.setTisId(PROGRAMME_3_ID);
+    programme3.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_3_NAME
+    ));
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setTisId(CURRICULUM_1_ID);
+    curriculum1.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_1_NAME
+    ));
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setTisId(CURRICULUM_2_ID);
+    curriculum2.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_1_ID)).thenReturn(Optional.of(curriculum1));
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.of(curriculum2));
+    when(programmeService.findById(PROGRAMME_1_ID)).thenReturn(Optional.of(programme1));
+    when(programmeService.findById(PROGRAMME_3_ID)).thenReturn(Optional.of(programme3));
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Sets.newSet(curriculumMembership1, curriculumMembership2));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_1_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership1));
+    when(curriculumMembershipService.findBySimilar(ALL_PERSON_ID, PROGRAMME_3_ID,
+        ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Sets.newSet(curriculumMembership2));
+
+    enricher.enrich(curriculumMembership1);
+    verify(enricher).syncAggregateCurriculumMembership(curriculumMembership1, true);
+    verify(enricher).syncAggregateCurriculumMembership(curriculumMembership2, false);
+
+    // the initial 'DELETE' and then 'LOAD' sync both use curriculumMembership
+    verify(tcsSyncService, times(2)).syncRecord(curriculumMembership1);
+  }
+
+  @Test
+  void shouldDeleteSolitaryCurriculumMembership() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID)));
+    curriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Collections.emptySet());
+
+    enricher.delete(curriculumMembership);
+
+    verify(tcsSyncService).syncRecord(curriculumMembership);
+  }
+
+  @Test
+  void shouldDeleteCurriculumMembershipFromSet() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID)));
+    curriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+
+    CurriculumMembership curriculumMembership1 = new CurriculumMembership();
+    curriculumMembership1.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A32_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID,
+        DATA_PROGRAMME_ID, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_ID,
+        DATA_CURRICULUM_ID, CURRICULUM_MEMBERSHIP_A32_CURRICULUM_ID,
+        DATA_CURRICULUM_MEMBERSHIP_TYPE, ALL_CURRICULUM_MEMBERSHIP_TYPE,
+        DATA_PROGRAMME_START_DATE, ALL_PROGRAMME_START_DATE,
+        DATA_PROGRAMME_END_DATE, ALL_PROGRAMME_END_DATE,
+        DATA_PROGRAMME_COMPLETION_DATE, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_COMPLETION_DATE)));
+    curriculumMembership1.setTisId(CURRICULUM_MEMBERSHIP_A32_TIS_ID);
+
+    Programme programme3 = new Programme();
+    programme3.setTisId(PROGRAMME_3_ID);
+    programme3.setData(Map.of(
+        PROGRAMME_NAME, PROGRAMME_3_NAME
+    ));
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setTisId(CURRICULUM_2_ID);
+    curriculum2.setData(Map.of(
+        CURRICULUM_NAME, CURRICULUM_2_NAME
+    ));
+
+    when(curriculumService.findById(CURRICULUM_2_ID)).thenReturn(Optional.of(curriculum2));
+    when(programmeService.findById(PROGRAMME_3_ID)).thenReturn(Optional.of(programme3));
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Collections.singleton(curriculumMembership1));
+    when(curriculumMembershipService
+        .findBySimilar(ALL_PERSON_ID, CURRICULUM_MEMBERSHIP_A32_PROGRAMME_ID,
+            ALL_CURRICULUM_MEMBERSHIP_TYPE, ALL_PROGRAMME_START_DATE, ALL_PROGRAMME_END_DATE))
+        .thenReturn(Collections.singleton(curriculumMembership1));
+
+    enricher.delete(curriculumMembership);
+
+    verify(enricher).syncAggregateCurriculumMembership(curriculumMembership1, false);
+
+    // 1 delete + 1 load
+    verify(tcsSyncService).syncRecord(curriculumMembership);
+    verify(tcsSyncService).syncRecord(curriculumMembership1);
+  }
+
+  @Test
+  void shouldNotRaiseExceptionIfCurriculumMembershipHasNoCurriculaJson() {
+
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setData(new HashMap<>(Map.of(
+        DATA_TIS_ID, CURRICULUM_MEMBERSHIP_A11_TIS_ID,
+        DATA_PERSON_ID, ALL_PERSON_ID)));
+    curriculumMembership.setTisId(CURRICULUM_MEMBERSHIP_A11_TIS_ID);
+
+    when(curriculumMembershipService.findByPersonId(ALL_PERSON_ID))
+        .thenReturn(Collections.emptySet());
+
+    enricher.enrich(curriculumMembership);
+
+    verify(tcsSyncService, times(2)).syncRecord(curriculumMembership);
+
+    Map<String, String> curriculumMembershipData = curriculumMembership.getData();
+    Set<Map<String, String>> curriculumMembershipCurricula =
+        getCurriculaFromJson(curriculumMembershipData.get(CURRICULUM_MEMBERSHIP_DATA_CURRICULA));
+    assertThat("Unexpected curricula size.", curriculumMembershipCurricula.size(),
+        is(0));
+  }
+
+  /**
+   * Get the Curricula from the curricula JSON string.
+   *
+   * @param curriculaJson The JSON string to get the curricula from.
+   * @return The curricula.
+   */
+  private Set<Map<String, String>> getCurriculaFromJson(String curriculaJson) {
+    ObjectMapper mapper = new ObjectMapper();
+
+    Set<Map<String, String>> curricula = new HashSet<>();
+    try {
+      curricula = mapper.readValue(curriculaJson, new TypeReference<>() {
+      });
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    return curricula;
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/CurriculumMembershipSyncServiceTest.java
@@ -1,0 +1,287 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.CurriculumMembershipRepository;
+
+class CurriculumMembershipSyncServiceTest {
+
+  private static final String ID = "40";
+  private static final String ID_2 = "140";
+
+  private static final String personId = "1";
+  private static final String programmeId = "1";
+  private static final String programmeMembershipType = "SUBSTANTIVE";
+  private static final String programmeStartDate = "2020-01-01";
+  private static final String programmeEndDate = "2021-01-02";
+
+  private CurriculumMembershipSyncService service;
+
+  private CurriculumMembershipRepository repository;
+
+  private CurriculumMembership curriculumMembership;
+
+  private DataRequestService dataRequestService;
+
+  private Map<String, String> whereMap;
+
+  private Map<String, String> whereMap2;
+
+  @BeforeEach
+  void setUp() {
+    dataRequestService = mock(DataRequestService.class);
+    repository = mock(CurriculumMembershipRepository.class);
+    service = new CurriculumMembershipSyncService(repository, dataRequestService);
+
+    curriculumMembership = new CurriculumMembership();
+    curriculumMembership.setTisId(ID);
+
+    whereMap = Map.of("id", ID);
+    whereMap2 = Map.of("id", ID_2);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotCurriculumMembership() {
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
+  }
+
+  @ParameterizedTest(name = "Should store records when operation is {0}.")
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  void shouldStoreRecords(Operation operation) {
+    curriculumMembership.setOperation(operation);
+
+    service.syncRecord(curriculumMembership);
+
+    verify(repository).save(curriculumMembership);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeleteRecordFromStore() {
+    curriculumMembership.setOperation(DELETE);
+
+    service.syncRecord(curriculumMembership);
+
+    verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByPersonIdWhenExists() {
+    when(repository.findByPersonId(ID)).thenReturn(Collections.singleton(curriculumMembership));
+
+    Set<CurriculumMembership> foundRecords = service.findByPersonId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    CurriculumMembership foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(curriculumMembership));
+
+    verify(repository).findByPersonId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdPersonWhenNotExists() {
+    when(repository.findByPersonId(ID)).thenReturn(Collections.emptySet());
+
+    Set<CurriculumMembership> foundRecords = service.findByPersonId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findByPersonId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByCurriculumIdWhenExists() {
+    when(repository.findByCurriculumId(ID)).thenReturn(Collections.singleton(curriculumMembership));
+
+    Set<CurriculumMembership> foundRecords = service.findByCurriculumId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    CurriculumMembership foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(curriculumMembership));
+
+    verify(repository).findByCurriculumId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdCurriculumWhenNotExists() {
+    when(repository.findByCurriculumId(ID)).thenReturn(Collections.emptySet());
+
+    Set<CurriculumMembership> foundRecords = service.findByCurriculumId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findByCurriculumId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByProgrammeIdWhenExists() {
+    when(repository.findByProgrammeId(ID)).thenReturn(Collections.singleton(curriculumMembership));
+
+    Set<CurriculumMembership> foundRecords = service.findByProgrammeId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    CurriculumMembership foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(curriculumMembership));
+
+    verify(repository).findByProgrammeId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdProgrammeWhenNotExists() {
+    when(repository.findByProgrammeId(ID)).thenReturn(Collections.emptySet());
+
+    Set<CurriculumMembership> foundRecords = service.findByProgrammeId(ID);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findByProgrammeId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordBySimilarCmWhenExists() {
+
+    when(repository.findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate))
+        .thenReturn(Collections.singleton(curriculumMembership));
+
+    Set<CurriculumMembership> foundRecords = service.findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+
+    CurriculumMembership foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected record.", foundRecord, sameInstance(curriculumMembership));
+
+    verify(repository).findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordBySimilarCmWhenNotExists() {
+    when(repository.findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate))
+        .thenReturn(Collections.emptySet());
+
+    Set<CurriculumMembership> foundRecords = service.findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
+    assertThat("Unexpected record count.", foundRecords.size(), is(0));
+
+    verify(repository).findBySimilar(personId,
+        programmeId, programmeMembershipType, programmeStartDate, programmeEndDate);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
+    service.request(ID);
+    verify(dataRequestService).sendRequest("CurriculumMembership", whereMap);
+  }
+
+  @Test
+  void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
+    service.request(ID);
+    service.request(ID);
+    verify(dataRequestService, atMostOnce()).sendRequest("CurriculumMembership", whereMap);
+    verifyNoMoreInteractions(dataRequestService);
+  }
+
+  @Test
+  void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
+    service.request(ID);
+
+    curriculumMembership.setOperation(DELETE);
+    service.syncRecord(curriculumMembership);
+
+    service.request(ID);
+    verify(dataRequestService, times(2))
+        .sendRequest("CurriculumMembership", whereMap);
+  }
+
+  @Test
+  void shouldSendRequestWhenRequestedDifferentIds() throws JsonProcessingException {
+    service.request(ID);
+    service.request("140");
+    verify(dataRequestService, atMostOnce()).sendRequest("CurriculumMembership", whereMap);
+    verify(dataRequestService, atMostOnce()).sendRequest("CurriculumMembership", whereMap2);
+  }
+
+  @Test
+  void shouldSendRequestWhenFirstRequestFails() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyMap());
+
+    service.request(ID);
+    service.request(ID);
+
+    verify(dataRequestService, times(2))
+        .sendRequest("CurriculumMembership", whereMap);
+  }
+
+  @Test
+  void shouldCatchAJsonProcessingExceptionIfThrown() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyMap());
+    assertDoesNotThrow(() -> service.request(ID));
+  }
+
+  @Test
+  void shouldThrowAnExceptionIfNotJsonProcessingException() throws JsonProcessingException {
+    IllegalStateException illegalStateException = new IllegalStateException("error");
+    doThrow(illegalStateException).when(dataRequestService).sendRequest(anyString(),
+        anyMap());
+    assertThrows(IllegalStateException.class, () -> service.request(ID));
+    assertEquals("error", illegalStateException.getMessage());
+  }
+}


### PR DESCRIPTION
Start using the new CurriculumMembership table events queue, but still populate a ProgrammeMembershipDTO and the same 'programmeMemberships' array in TraineeProfile MongoDB.

Note that ProgrammeMembership sync is turned-off by this PR, but the work to refactor and re-enable this with the new ProgrammeMembership table design will only be done once the revised table is finalised.

Needs https://github.com/Health-Education-England/TIS-OPS/pull/420 to be merged to be 'activated'

TIS21-2509