### PR TITLE
feat: handle deletion of personalDetails data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.22.0"
+version = "0.23.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -153,17 +153,14 @@ public class TcsSyncService implements SyncService {
         } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PLACEMENT))) {
           restTemplate.delete(serviceUrl + API_ID_TEMPLATE + "/{placementTisId}",
               apiPath, dto.getTraineeTisId(), dto.getTisId());
+        } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PERSON))) {
+          personService.deleteById(dto.getTraineeTisId());
         } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_QUALIFICATION))) {
           log.warn("Unhandled Qualification operation {}.", operationType);
         } else {
           TraineeDetailsDto emptyDto = new TraineeDetailsDto();
           restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, emptyDto, Object.class,
               apiPath, dto.getTraineeTisId());
-
-          // Delete from sync lookup data where appropriate.
-          if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PERSON))) {
-            personService.deleteById(dto.getTraineeTisId());
-          }
         }
         break;
       default:

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -153,10 +153,17 @@ public class TcsSyncService implements SyncService {
         } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PLACEMENT))) {
           restTemplate.delete(serviceUrl + API_ID_TEMPLATE + "/{placementTisId}",
               apiPath, dto.getTraineeTisId(), dto.getTisId());
-        } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PERSON))) {
-          personService.deleteById(dto.getTraineeTisId());
+        } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_QUALIFICATION))) {
+          log.warn("Unhandled Qualification operation {}.", operationType);
         } else {
-          log.warn("Unhandled record operation {}.", operationType);
+          TraineeDetailsDto emptyDto = new TraineeDetailsDto();
+          restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, emptyDto, Object.class,
+              apiPath, dto.getTraineeTisId());
+
+          // Delete from sync lookup data where appropriate.
+          if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_PERSON))) {
+            personService.deleteById(dto.getTraineeTisId());
+          }
         }
         break;
       default:

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -181,7 +181,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(name =
       "Should patch basic details when operation is {0}, role is valid and table is Person")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchBasicDetailsWhenValidOperations(Operation operation) {
     Person person = new Person();
     person.setTisId("idValue");
@@ -195,8 +195,10 @@ class TcsSyncServiceTest {
     service.syncRecord(person);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setPublicHealthNumber("publicHealthNumberValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setPublicHealthNumber("publicHealthNumberValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("basic-details"),
@@ -206,7 +208,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should patch contact details when operation is {0} and table is ContactDetails")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchContactDetails(Operation operation) {
     recrd.setTable("ContactDetails");
     recrd.setOperation(operation);
@@ -219,20 +221,22 @@ class TcsSyncServiceTest {
     service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setTitle("titleValue");
-    expectedDto.setForenames("forenamesValue");
-    expectedDto.setKnownAs("knownAsValue");
-    expectedDto.setSurname("surnameValue");
-    expectedDto.setMaidenName("maidenNameValue");
-    expectedDto.setTelephoneNumber("telephoneNumberValue");
-    expectedDto.setMobileNumber("mobileNumberValue");
-    expectedDto.setEmail("emailValue");
-    expectedDto.setAddress1("address1Value");
-    expectedDto.setAddress2("address2Value");
-    expectedDto.setAddress3("address3Value");
-    expectedDto.setAddress4("address4Value");
-    expectedDto.setPostCode("postCodeValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setTitle("titleValue");
+      expectedDto.setForenames("forenamesValue");
+      expectedDto.setKnownAs("knownAsValue");
+      expectedDto.setSurname("surnameValue");
+      expectedDto.setMaidenName("maidenNameValue");
+      expectedDto.setTelephoneNumber("telephoneNumberValue");
+      expectedDto.setMobileNumber("mobileNumberValue");
+      expectedDto.setEmail("emailValue");
+      expectedDto.setAddress1("address1Value");
+      expectedDto.setAddress2("address2Value");
+      expectedDto.setAddress3("address3Value");
+      expectedDto.setAddress4("address4Value");
+      expectedDto.setPostCode("postCodeValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("contact-details"),
@@ -242,7 +246,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should patch GDC details when operation is {0} and table is GdcDetails")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchGdcDetails(Operation operation) {
     Map<String, String> data = new HashMap<>();
     data.put("gdcNumber", "gdcNumberValue");
@@ -259,9 +263,11 @@ class TcsSyncServiceTest {
     service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setGdcNumber("gdcNumberValue");
-    expectedDto.setGdcStatus("gdcStatusValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setGdcNumber("gdcNumberValue");
+      expectedDto.setGdcStatus("gdcStatusValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("gdc-details"),
@@ -271,7 +277,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should patch GMC details when operation is {0} and table is GmcDetails")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchGmcDetails(Operation operation) {
     Map<String, String> data = new HashMap<>();
     data.put("gmcNumber", "gmcNumberValue");
@@ -288,9 +294,11 @@ class TcsSyncServiceTest {
     service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setGmcNumber("gmcNumberValue");
-    expectedDto.setGmcStatus("gmcStatusValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setGmcNumber("gmcNumberValue");
+      expectedDto.setGmcStatus("gmcStatusValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("gmc-details"),
@@ -300,7 +308,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should patch person owner when operation is {0} and table is PersonOwner")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchPersonOwnerInfo(Operation operation) {
     Map<String, String> data = new HashMap<>();
     data.put("owner", "personOwnerValue");
@@ -316,8 +324,10 @@ class TcsSyncServiceTest {
     service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setPersonOwner("personOwnerValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setPersonOwner("personOwnerValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("person-owner"),
@@ -327,7 +337,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should patch personal info when operation is {0} and table is PersonalDetails")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
   void shouldPatchPersonalInfo(Operation operation) {
     Map<String, String> data = new HashMap<>();
     data.put("dateOfBirth", "1978-03-23");
@@ -343,9 +353,11 @@ class TcsSyncServiceTest {
     service.syncRecord(recrd);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    expectedDto.setTraineeTisId("idValue");
-    expectedDto.setDateOfBirth("1978-03-23");
-    expectedDto.setGender("genderValue");
+    if (!operation.equals(DELETE)) {
+      expectedDto.setTraineeTisId("idValue");
+      expectedDto.setDateOfBirth("1978-03-23");
+      expectedDto.setGender("genderValue");
+    }
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("personal-info"),
@@ -434,9 +446,8 @@ class TcsSyncServiceTest {
   }
 
   @ParameterizedTest(name = "Should not delete when operation is DELETE and table is {0}")
-  @ValueSource(strings = {"ContactDetails", "GdcDetails", "GmcDetails", "Person", "PersonOwner",
-      "PersonalDetails", "Qualification", "Curriculum"})
-  void shouldNotDeleteIfNotProgrammeMembershipOrPlacement(String tableName) {
+  @ValueSource(strings = {"Qualification", "Curriculum"})
+  void shouldNotDeleteIfNotImplemented(String tableName) {
     Map<String, String> data = Map.of(
         "personId", "personIdValue",
         "traineeId", "traineeIdValue");

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -181,7 +181,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(name =
       "Should patch basic details when operation is {0}, role is valid and table is Person")
-  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
   void shouldPatchBasicDetailsWhenValidOperations(Operation operation) {
     Person person = new Person();
     person.setTisId("idValue");
@@ -195,10 +195,8 @@ class TcsSyncServiceTest {
     service.syncRecord(person);
 
     TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setPublicHealthNumber("publicHealthNumberValue");
-    }
+    expectedDto.setTraineeTisId("idValue");
+    expectedDto.setPublicHealthNumber("publicHealthNumberValue");
 
     verify(restTemplate)
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("basic-details"),
@@ -398,6 +396,19 @@ class TcsSyncServiceTest {
         .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("qualification"),
             eq("personIdValue"));
     verifyNoMoreInteractions(restTemplate);
+  }
+
+  @Test
+  void shouldDeletePerson() {
+    recrd.setTable("Person");
+    recrd.setOperation(DELETE);
+
+    Optional<Person> person = Optional.of(new Person());
+    when(personService.findById(anyString())).thenReturn(person);
+
+    service.syncRecord(recrd);
+
+    verify(personService).deleteById("idValue");
   }
 
   @ParameterizedTest(


### PR DESCRIPTION
Handle the deletion of TIS data that feeds the `traineeProfile` object,
this can be achieved by patching with a blank DTO to purge the
associated data.

TIS21-2549