### PR TITLE
feat: purge data associated with deleted records

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.24.0"
+version = "0.25.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
@@ -25,7 +25,6 @@ import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
-import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
@@ -62,11 +61,5 @@ public class PostEventListener extends AbstractMongoEventListener<Post> {
       placement.setOperation(Operation.LOAD);
       messagingTemplate.convertAndSend(placementQueueUrl, placement);
     }
-  }
-
-  @Override
-  public void onAfterDelete(AfterDeleteEvent<Post> event) {
-    // TODO: Implement.
-    super.onAfterDelete(event);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
@@ -25,7 +25,6 @@ import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
-import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
@@ -62,11 +61,5 @@ public class SiteEventListener extends AbstractMongoEventListener<Site> {
       placement.setOperation(Operation.LOAD);
       messagingTemplate.convertAndSend(placementQueueUrl, placement);
     }
-  }
-
-  @Override
-  public void onAfterDelete(AfterDeleteEvent<Site> event) {
-    // TODO: Implement.
-    super.onAfterDelete(event);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
@@ -31,8 +31,10 @@ import static org.mockito.Mockito.when;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import java.util.Collections;
 import java.util.Set;
+import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
@@ -95,5 +97,48 @@ class TrustEventListenerTest {
 
     verify(messagingTemplate).convertAndSend(POST_QUEUE_URL, post3);
     assertThat("Unexpected table operation.", post3.getOperation(), is(Operation.LOAD));
+  }
+
+  @Test
+  void shouldNotInteractWithPostQueueAfterDeleteWhenNoRelatedPosts() {
+    Document document = new Document();
+    document.append("_id", "trust1");
+    AfterDeleteEvent<Trust> event = new AfterDeleteEvent<>(document, Trust.class, "trust");
+
+    when(postService.findByEmployingBodyId("trust1")).thenReturn(Collections.emptySet());
+    when(postService.findByTrainingBodyId("trust1")).thenReturn(Collections.emptySet());
+
+    listener.onAfterDelete(event);
+
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldSendRelatedPostsToQueueAfterDeleteWhenRelatedPosts() {
+    Document document = new Document();
+    document.append("_id", "trust1");
+
+    Post post1 = new Post();
+    post1.setTisId("post1");
+
+    Post post2 = new Post();
+    post2.setTisId("post2");
+
+    Post post3 = new Post();
+    post3.setTisId("post3");
+    when(postService.findByTrainingBodyId("trust1")).thenReturn(Set.of(post1, post2));
+    when(postService.findByEmployingBodyId("trust1")).thenReturn(Set.of(post2, post3));
+
+    AfterDeleteEvent<Trust> event = new AfterDeleteEvent<>(document, Trust.class, "trust");
+    listener.onAfterDelete(event);
+
+    verify(messagingTemplate).convertAndSend(POST_QUEUE_URL, post1);
+    assertThat("Unexpected table operation.", post1.getOperation(), is(Operation.DELETE));
+
+    verify(messagingTemplate).convertAndSend(POST_QUEUE_URL, post2);
+    assertThat("Unexpected table operation.", post2.getOperation(), is(Operation.DELETE));
+
+    verify(messagingTemplate).convertAndSend(POST_QUEUE_URL, post3);
+    assertThat("Unexpected table operation.", post3.getOperation(), is(Operation.DELETE));
   }
 }


### PR DESCRIPTION
When a `DELETE` message is received for Specialty or Trust, the
associated PlacementSpecialtys or Posts should also be deleted from the
sync lookup tables.

Remove `onAfterDelete` methods from Post and Site event listeners, they
are directly associated with placements and deleting the placement would
force deletion from the trainee profile. Removing a placement from the
trainee profile should only be done when the placement itself is
deleted.

TIS21-2549