### PR TITLE
feat: remove enrichment on placementspecialty delete

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -359,39 +359,6 @@ public class PlacementEnricherFacade {
     return trust.getData().get(TRUST_NAME);
   }
 
-  private boolean isPlacementSpecialtyExists(String placementId) {
-    if (placementId != null) {
-      Optional<PlacementSpecialty> placementSpecialty = placementSpecialtyService
-          .findById(placementId);
-      return placementSpecialty.isPresent();
-    }
-    return false;
-  }
-
-  /**
-   * Determine whether the PlacementSpecialty being deleted has been deleted correctly, i.e. the
-   * Placement has also been deleted (isEmpty()) or has been superseded by a new PlacementSpecialty.
-   * Enrichment of the Placement (prompting a request of the PlacementSpecialty) will be triggered
-   * if deletion was incorrect according to the conditions above.
-   *
-   * @param placementId of the PlacementSpecialty to be deleted.
-   */
-  public void restartPlacementEnrichmentIfDeletionIncorrect(String placementId) {
-    if (placementId != null) {
-      Optional<Placement> placement = placementService.findById(placementId);
-      boolean placementSpecialtyDeletedCorrectly =
-          placement.isEmpty() || isPlacementSpecialtyExists(placementId);
-      if (!placementSpecialtyDeletedCorrectly) {
-        enrich(placement.get());
-        log.warn(
-            "PlacementSpecialty with placementId {} got deleted but its placement is still "
-                + "existing without an associated placementSpecialty. Enrichment of Placement "
-                + "has been restarted.",
-            placementId);
-      }
-    }
-  }
-
   /**
    * Get the specialty for the given id, if the specialty is not found it will be requested.
    *


### PR DESCRIPTION
When a placement specialty is deleted additional checks are made on
whether the associated placement is already deleted, or whether the
placement already has a new specialty link.
If these are not true then the placement is re-enriched, requesting any
missing data as part of the process.

While there is no guarantee of order received, there is an expectation
that the sync service would eventually get any missing messages, either
the placement deletion or the new placement specialty.

The existing re-enrichment functionality on delete should be removed for
consistency with other related data, which are currently just deleted
without any affect on the placement - deletion nor enrichment.
Any handling of similar scenarios should consider all data deletions
that may affect a placement and ensure consistency for all.

TIS21-2549