### PR TITLE
fix: no Placement request for PlacementSpecialty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.28.0"
+version = "0.28.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
@@ -46,8 +46,6 @@ public class PlacementSpecialtyEventListener extends
         Placement placement = optionalPlacement.get();
         placement.setOperation(Operation.LOAD);
         messagingTemplate.convertAndSend(placementQueueUrl, placement);
-      } else {
-        placementService.request(placementId);
       }
     }
   }


### PR DESCRIPTION
When handling PlacementSpecialty events the listener requests the
associated Placement if it is not found in the lookup data.
When doing a full load on an empty database this causes a large number
of requests, as no matter which order Placement and PlacementSpecialty
are loaded the other can not yet exist and will always be requested.

Removing the request from the PlacementSpecialty event listener allows
the PlacementSpecialty lookup data to be loaded prior to the Placements.

In the standard use case of a PlacementSpecialty being created, it is
fair to expect that the Placement will already exist in the lookup data,
or else the Placement insert message would be received eventually.

The Placement should still have the ability to request
PlacementSpecialty records should none exist in the lookup.

TIS21-2549