### PR TITLE
Fix: compound index creation

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
@@ -14,7 +14,6 @@ import io.mongock.api.annotations.RollbackExecution;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
@@ -14,7 +14,6 @@ import io.mongock.api.annotations.RollbackExecution;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.data.domain.Sort;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/CopyProgrammeMembershipToCurriculumMembership.java
@@ -13,6 +13,9 @@ import io.mongock.api.annotations.RollbackBeforeExecution;
 import io.mongock.api.annotations.RollbackExecution;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.data.domain.Sort;
@@ -44,6 +47,7 @@ public class CopyProgrammeMembershipToCurriculumMembership {
   public void createCurriculumMembershipTable() {
     IndexOperations indexOperationsSource;
     IndexOperations indexOperationsDest;
+    AtomicInteger compoundIndexCount = new AtomicInteger(0);
 
     if (!mongoTemplate.collectionExists(DEST_COLLECTION)) {
       mongoTemplate.createCollection(DEST_COLLECTION);
@@ -62,6 +66,7 @@ public class CopyProgrammeMembershipToCurriculumMembership {
         Document keys = new Document();
         idxFields.forEach(idxField -> keys.append(idxField.getKey(), 1));
         CompoundIndexDefinition compoundIndexDefinition = new CompoundIndexDefinition(keys);
+        compoundIndexDefinition.named("compoundIdx_" + compoundIndexCount.incrementAndGet());
         indexOperationsDest.ensureIndex(compoundIndexDefinition);
       }
     });


### PR DESCRIPTION
Staging mongo is v3.6.0 which fails to create the compound index with its default name, throwing a 'namespace name generated from index name is too long' exception, since the default name is more than 127 bytes
('data.programmeId_1_data.curriculumId_1_data.personId_1_data.programmeMembershipType_1_data.programmeStartDate_1_data.programmeEndDate_1' is 135 characters).

This should fix this. Since the other indexes are all prefixed 'data.' the name(s) for the compound index(es) should never collide with these.

TIS21-2509