### PR TITLE
chore: enabled event debug logging

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,14 @@ application:
 logging:
   level:
     root: ${LOGGING_ROOT:INFO}
-    uk.nhs.hee.tis.trainee.sync.service: ${LOGGING_SERVICE:DEBUG}
+    uk:
+      nhs:
+        hee:
+          tis:
+            trainee:
+              sync:
+                event: ${LOGGING_EVENT:DEBUG}
+                service: ${LOGGING_SERVICE:DEBUG}
 
 sentry:
   dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
The sync service occasionally requests placement specialty for
placements with invalid IDs, enable event debug logging to give more
insight in to the incoming data to identify when/where the invalid ID
enters the sync service.

TIS21-SHED