### PR TITLE
fix: ignore 404 errors when deleting resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.30.0"
+version = "0.30.1"
 sourceCompatibility = "11"
 
 configurations {


### PR DESCRIPTION
Whn deleting objects from the `tis-trainee-details` database a 404
response is sent if the object no longer exists. Due to the possibility
for duplicate messages etc. this scenario should be accepted and not
result in messages added to the DLQ.
Update `TcsSyncService` to catch and log 404 errors on deletion instead
of throwing the received exception.

TIS21-3124