### PR TITLE
chore: keep mapstruct versions in sync

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,10 @@ dependencies {
   annotationProcessor "org.projectlombok:lombok"
 
   // MapStruct
-  implementation "org.mapstruct:mapstruct:1.5.1.Final"
-  annotationProcessor "org.mapstruct:mapstruct-processor:1.5.2.Final"
-  testAnnotationProcessor "org.mapstruct:mapstruct-processor:1.5.1.Final"
+  ext.mapstructVersion = "1.5.2.Final"
+  implementation "org.mapstruct:mapstruct:${mapstructVersion}"
+  annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+  testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:5.7.4"


### PR DESCRIPTION
Update the Mapstruct dependency versioning to use a shared variable.

TIS21-SHED