### PR TITLE
fix: add logging for trainee not found

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -129,6 +129,10 @@ public class TcsSyncService implements SyncService {
       }
     } else {
       doSync = findById(dto.getTraineeTisId());
+      if (!doSync) {
+        log.info("Trainee with id {} was not found, so {} table data will not be sync'd",
+            dto.getTraineeTisId(), recrd.getTable());
+      }
     }
 
     if (doSync) {


### PR DESCRIPTION
The purpose of this is to confirm or refute a possible cause for the bug
below, since there is no DocumentDB query logging.

Based on observed instances of the bug, data is sometimes logged as arriving in
tis-trainee-sync but there is no matching log entry in
tis-trainee-details to show it being processed, nor an exception from
the tis-trainee-details API call. As such, the most likely scenario is
that there is an intermittent failure with the findById(), either at a
database or cache level.

TIS21-3195: Single-trainee data refresh missing data