### PR TITLE
fix: update actions/setup-java in cicd-workflow

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           cache: gradle
           distribution: temurin
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           cache: gradle
           distribution: temurin
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           cache: gradle
           distribution: temurin
@@ -111,7 +111,7 @@ jobs:
           path: build/reports
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.6.0
         with:
           cache: gradle
           distribution: temurin


### PR DESCRIPTION
update actions/setup-java to 3.6.0
attempt to fix the warning: `The set-output command is deprecated and will be disabled soon`

Update this repo as a test. Will make sure Dependapot is covering version update in all other repos in the future.

Reference:
https://github.com/actions/setup-java/issues/393
https://github.com/GetStream/stream-chat-android/issues/4279