### PR TITLE
chore: use correct queue param names

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -66,11 +66,11 @@
         },
         {
           "name": "DELETE_PLACEMENT_TOPIC_ARN",
-          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-placement-event"
+          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-placement"
         },
         {
           "name": "DELETE_PROGRAMME_MEMBERSHIP_TOPIC_ARN",
-          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-programme-membership-event"
+          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-programme-membership"
         },
         {
           "name": "REDIS_HOST",


### PR DESCRIPTION
Update the task definition template to use
`/tis/trainee/sync/${environment}/queue-url/delete-placement` instead of `/tis/trainee/sync/${environment}/queue-url/delete-placement-event` and `/tis/trainee/sync/${environment}/queue-url/delete-programme-membership` instead of
`/tis/trainee/sync/${environment}/queue-url/delete-programme-membership-event`.

TIS21-4128
TIS21-4301