### PR TITLE
fix: use new SNS params instead of SQS queues

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -66,11 +66,11 @@
         },
         {
           "name": "DELETE_PLACEMENT_TOPIC_ARN",
-          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-placement"
+          "valueFrom": "/tis/trainee/sync/${environment}/topic-arn/delete-placement-event"
         },
         {
           "name": "DELETE_PROGRAMME_MEMBERSHIP_TOPIC_ARN",
-          "valueFrom": "/tis/trainee/sync/${environment}/queue-url/delete-programme-membership"
+          "valueFrom": "/tis/trainee/sync/${environment}/topic-arn/delete-programme-membership-event"
         },
         {
           "name": "REDIS_HOST",


### PR DESCRIPTION
The current params point to SQS queues but should point to topic ARNs, the missing parameters have now been added. Update the task definition template to point to the new params.

TIS21-4128
TIS21-4301