### PR TITLE
Refactor/programme membership and curriculum membership

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.35.0"
+version = "0.35.1"
 
 configurations {
   compileOnly {
@@ -57,9 +57,6 @@ dependencies {
   // Amazon SQS
   implementation "io.awspring.cloud:spring-cloud-starter-aws"
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging"
-
-  //Lettuce
-  //implementation "io.lettuce:lettuce-core:6.1.8.RELEASE"
 
   implementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.35.1"
+version = "0.35.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
@@ -56,16 +56,14 @@ public class MongoConfiguration {
     placementIndexOps.ensureIndex(new Index().on("data.siteId", Direction.ASC));
 
     IndexOperations programmeMembershipIndexOps = template.indexOps(ProgrammeMembership.class);
-    programmeMembershipIndexOps.ensureIndex(new Index().on("data.programmeId", Direction.ASC));
-    programmeMembershipIndexOps.ensureIndex(new Index().on("data.curriculumId", Direction.ASC));
-    programmeMembershipIndexOps.ensureIndex(new Index().on("data.personId", Direction.ASC));
+    programmeMembershipIndexOps.ensureIndex(new Index().on("programmeId", Direction.ASC));
+    programmeMembershipIndexOps.ensureIndex(new Index().on("personId", Direction.ASC));
     Document keys = new Document();
-    keys.put("data.programmeId", 1);
-    keys.put("data.curriculumId", 1);
-    keys.put("data.personId", 1);
-    keys.put("data.programmeMembershipType", 1);
-    keys.put("data.programmeStartDate", 1);
-    keys.put("data.programmeEndDate", 1);
+    keys.put("programmeId", 1);
+    keys.put("personId", 1);
+    keys.put("programmeMembershipType", 1);
+    keys.put("programmeStartDate", 1);
+    keys.put("programmeEndDate", 1);
     Index programmeMembershipCompoundIndex = new CompoundIndexDefinition(keys)
         .named("programmeMembershipCompoundIndex");
     programmeMembershipIndexOps.ensureIndex(programmeMembershipCompoundIndex);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/RedisConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/RedisConfig.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.sync.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import io.lettuce.core.RedisClient;
@@ -57,7 +58,8 @@ public class RedisConfig extends CachingConfigurerSupport {
   @Value("${spring.redis.timeout}")
   private Long timeout;
 
-  /** Note that the equivalent requests-cache configurations are imported into
+  /**
+   * Note that the equivalent requests-cache configurations are imported into
    * {@link uk.nhs.hee.tis.trainee.sync.service.RequestCacheService}.
    */
   @Value("${spring.redis.time-to-live}")
@@ -107,7 +109,8 @@ public class RedisConfig extends CachingConfigurerSupport {
   public RedisCacheConfiguration cacheConfiguration() {
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper
-        .activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), DefaultTyping.NON_FINAL)
+        .activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), DefaultTyping.NON_FINAL,
+            As.PROPERTY)
         .findAndRegisterModules();
     return RedisCacheConfiguration.defaultCacheConfig()
         .entryTtl(Duration.ofMinutes(dataTtl))

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/RedisConfig.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/RedisConfig.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import java.time.Duration;
@@ -103,11 +105,14 @@ public class RedisConfig extends CachingConfigurerSupport {
    */
   @Bean
   public RedisCacheConfiguration cacheConfiguration() {
-
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper
+        .activateDefaultTyping(objectMapper.getPolymorphicTypeValidator(), DefaultTyping.NON_FINAL)
+        .findAndRegisterModules();
     return RedisCacheConfiguration.defaultCacheConfig()
         .entryTtl(Duration.ofMinutes(dataTtl))
         //.disableCachingNullValues() - i.e. allow NULLs to be cached
         .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-            new GenericJackson2JsonRedisSerializer()));
+            new GenericJackson2JsonRedisSerializer(objectMapper)));
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
@@ -33,6 +34,7 @@ import uk.nhs.hee.tis.trainee.sync.facade.ProgrammeMembershipEnricherFacade;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
 
+@Slf4j
 @Component
 public class ProgrammeMembershipEventListener
     extends AbstractMongoEventListener<ProgrammeMembership> {
@@ -54,9 +56,7 @@ public class ProgrammeMembershipEventListener
   @Override
   public void onAfterSave(AfterSaveEvent<ProgrammeMembership> event) {
     super.onAfterSave(event);
-
-    ProgrammeMembership programmeMembership = event.getSource();
-    programmeMembershipEnricher.enrich(programmeMembership);
+    log.info("Skipping enrichment for deprecated ProgrammeMembership type.");
   }
 
   /**
@@ -89,7 +89,7 @@ public class ProgrammeMembershipEventListener
     ProgrammeMembership programmeMembership =
         programmeMembershipCache.get(event.getSource().getString("_id"), ProgrammeMembership.class);
     if (programmeMembership != null) {
-      programmeMembershipEnricher.delete(programmeMembership);
+      log.info("Skipping enrichment for deprecated ProgrammeMembership type.");
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapper.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.mapper;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+/**
+ * A mapper to convert between ProgrammeMembership data types.
+ */
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface ProgrammeMembershipMapper {
+
+  /**
+   * Map a record data map to a ProgrammeMembership.
+   *
+   * @param recordData The map to convert.
+   * @return The mapped ProgrammeMembership.
+   */
+  ProgrammeMembership toEntity(Map<String, String> recordData);
+
+  /**
+   * Convert a ProgrammeMembership to a Record.
+   *
+   * @param programmeMembership The ProgrammeMembership to map.
+   * @return The mapped Record.
+   */
+  default Record toRecord(ProgrammeMembership programmeMembership) {
+    Record programmeMembershipRecord = new Record();
+
+    ObjectMapper objectMapper = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    Map<String, String> recordData = objectMapper.convertValue(programmeMembership,
+        new TypeReference<>() {
+        });
+
+    programmeMembershipRecord.setData(recordData);
+
+    UUID uuid = programmeMembership.getUuid();
+    programmeMembershipRecord.setTisId(uuid == null ? null : uuid.toString());
+    return programmeMembershipRecord;
+  }
+
+  /**
+   * Convert multiple ProgrammeMemberships to Records.
+   *
+   * @param programmeMemberships The ProgrammeMemberships to map.
+   * @return The mapped Records.
+   */
+  Set<Record> toRecords(Set<ProgrammeMembership> programmeMemberships);
+
+  @BeforeMapping
+  default void stripNullMapValues(Map<String, String> recordData) {
+    recordData.values().removeIf(Objects::isNull);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
@@ -21,15 +21,29 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.Data;
+import org.springframework.data.annotation.Id;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
-
-@Component(ProgrammeMembership.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class ProgrammeMembership extends Record {
+@Data
+public class ProgrammeMembership {
 
   public static final String ENTITY_NAME = "ProgrammeMembership";
 
+  @Id
+  private UUID uuid;
+  private String programmeMembershipType;
+  private LocalDate programmeStartDate;
+  private LocalDate programmeEndDate;
+  private Long programmeId;
+  private Long trainingNumberId;
+  private Long personId;
+  private String rotation;
+  private Long rotationId;
+  private String trainingPathway;
+  private String leavingReason;
+  /* legacy */ private String leavingDestination;
+  private Instant amendedDate;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/ProgrammeMembershipRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/ProgrammeMembershipRepository.java
@@ -21,47 +21,41 @@
 
 package uk.nhs.hee.tis.trainee.sync.repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
-import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 
 @CacheConfig(cacheNames = ProgrammeMembership.ENTITY_NAME)
-@Repository
 public interface ProgrammeMembershipRepository
-    extends MongoRepository<ProgrammeMembership, String> {
+    extends MongoRepository<ProgrammeMembership, UUID> {
 
   @Cacheable
   @Override
-  Optional<ProgrammeMembership> findById(String id);
+  Optional<ProgrammeMembership> findById(UUID uuid);
 
-  @CachePut(key = "#entity.tisId")
+  @CachePut(key = "#entity.uuid")
   @Override
   <T extends ProgrammeMembership> T save(T entity);
 
   @CacheEvict
   @Override
-  void deleteById(String id);
+  void deleteById(UUID uuid);
 
-  @Query("{ 'data.programmeId' : ?0}")
-  Set<ProgrammeMembership> findByProgrammeId(String programmeId);
+  Set<ProgrammeMembership> findByProgrammeId(Long programmeId);
 
-  @Query("{ 'data.curriculumId' : ?0}")
-  Set<ProgrammeMembership> findByCurriculumId(String curriculumId);
+  Set<ProgrammeMembership> findByPersonId(Long personId);
 
-  @Query("{ 'data.personId' : ?0}")
-  Set<ProgrammeMembership> findByPersonId(String personId);
-
-  @Query("{ $and: [ { 'data.personId' : ?0}, { 'data.programmeId' : ?1 }, "
-      + "{ 'data.programmeMembershipType' : ?2}, { 'data.programmeStartDate' : ?3}, "
-      + "{ 'data.programmeEndDate' : ?4} ] }")
-  Set<ProgrammeMembership> findBySimilar(String personId,
-                                                String programmeId, String programmeMembershipType,
-                                                String programmeStartDate, String programmeEndDate);
+  @Query("{ $and: [ { 'personId' : ?0}, { 'programmeId' : ?1 }, "
+      + "{ 'programmeMembershipType' : ?2}, { 'programmeStartDate' : ?3}, "
+      + "{ 'programmeEndDate' : ?4} ] }")
+  Set<ProgrammeMembership> findBySimilar(Long personId, Long programmeId,
+      String programmeMembershipType, LocalDate programmeStartDate, LocalDate programmeEndDate);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ProgrammeMembershipSyncService.java
@@ -24,11 +24,15 @@ package uk.nhs.hee.tis.trainee.sync.service;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.LocalDate;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.repository.ProgrammeMembershipRepository;
@@ -42,73 +46,75 @@ public class ProgrammeMembershipSyncService implements SyncService {
   private final DataRequestService dataRequestService;
 
   private final RequestCacheService requestCacheService;
+  private final ProgrammeMembershipMapper mapper;
 
   ProgrammeMembershipSyncService(ProgrammeMembershipRepository repository,
-      DataRequestService dataRequestService, RequestCacheService requestCacheService) {
+      DataRequestService dataRequestService, RequestCacheService requestCacheService,
+      ProgrammeMembershipMapper mapper) {
     this.repository = repository;
     this.dataRequestService = dataRequestService;
     this.requestCacheService = requestCacheService;
+    this.mapper = mapper;
   }
 
   @Override
-  public void syncRecord(Record programmeMembership) {
-    if (!(programmeMembership instanceof ProgrammeMembership)) {
-      String message = String.format("Invalid record type '%s'.", programmeMembership.getClass());
-      throw new IllegalArgumentException(message);
-    }
+  public void syncRecord(Record programmeMembershipRecord) {
+    ProgrammeMembership programmeMembership = mapper.toEntity(programmeMembershipRecord.getData());
 
-    if (programmeMembership.getOperation().equals(DELETE)) {
-      repository.deleteById(programmeMembership.getTisId());
+    if (programmeMembershipRecord.getOperation().equals(DELETE)) {
+      repository.deleteById(programmeMembership.getUuid());
     } else {
-      repository.save((ProgrammeMembership) programmeMembership);
+      repository.save(programmeMembership);
     }
 
     requestCacheService.deleteItemFromCache(ProgrammeMembership.ENTITY_NAME,
-        programmeMembership.getTisId());
+        programmeMembership.getUuid().toString());
   }
 
-  public Optional<ProgrammeMembership> findById(String id) {
-    return repository.findById(id);
+  public Optional<ProgrammeMembership> findById(String uuid) {
+    return repository.findById(UUID.fromString(uuid));
   }
 
   public Set<ProgrammeMembership> findByProgrammeId(String programmeId) {
-    return repository.findByProgrammeId(programmeId);
+    return repository.findByProgrammeId(Long.parseLong(programmeId));
   }
 
   public Set<ProgrammeMembership> findByCurriculumId(String curriculumId) {
-    return repository.findByCurriculumId(curriculumId);
+    // TODO: get PMs for curriculum ID.
+    return Collections.emptySet();
   }
 
   public Set<ProgrammeMembership> findByPersonId(String personId) {
-    return repository.findByPersonId(personId);
+    return repository.findByPersonId(Long.parseLong(personId));
   }
 
-  public Set<ProgrammeMembership> findBySimilar(String personId,
-      String programmeId,
-      String programmeMembershipType,
-      String programmeStartDate,
-      String programmeEndDate) {
-    return repository.findBySimilar(personId, programmeId, programmeMembershipType,
-        programmeStartDate, programmeEndDate);
+  public Set<ProgrammeMembership> findBySimilar(String personId, String programmeId,
+      String programmeMembershipType, String programmeStartDate, String programmeEndDate) {
+    return repository.findBySimilar(Long.parseLong(personId), Long.parseLong(programmeId),
+        programmeMembershipType,
+        LocalDate.parse(programmeStartDate), LocalDate.parse(programmeEndDate));
   }
 
   /**
-   * Make a request to retrieve a specific post.
+   * Make a request to retrieve a specific programme membership.
    *
-   * @param id The id of the post to be retrieved.
+   * @param uuid The uuid of the post to be retrieved.
    */
-  public void request(String id) {
-    if (!requestCacheService.isItemInCache(ProgrammeMembership.ENTITY_NAME, id)) {
-      log.info("Sending request for ProgrammeMembership [{}]", id);
+  public void request(UUID uuid) {
+    String uuidString = uuid.toString();
+
+    if (!requestCacheService.isItemInCache(ProgrammeMembership.ENTITY_NAME, uuidString)) {
+      log.info("Sending request for ProgrammeMembership [{}]", uuidString);
 
       try {
-        requestCacheService.addItemToCache(ProgrammeMembership.ENTITY_NAME, id,
-            dataRequestService.sendRequest(ProgrammeMembership.ENTITY_NAME, Map.of("id", id)));
+        requestCacheService.addItemToCache(ProgrammeMembership.ENTITY_NAME, uuidString,
+            dataRequestService.sendRequest(ProgrammeMembership.ENTITY_NAME,
+                Map.of("uuid", uuidString)));
       } catch (JsonProcessingException e) {
         log.error("Error while trying to request a ProgrammeMembership", e);
       }
     } else {
-      log.debug("Already requested ProgrammeMembership [{}].", id);
+      log.debug("Already requested ProgrammeMembership [{}].", uuidString);
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/RecordService.java
@@ -57,12 +57,6 @@ public class RecordService {
           recrd.getSchema(), recrd.getTable());
       return;
     }
-    if (recrd.getSchema().equals("tcs")
-        && recrd.getTable().equals(ProgrammeMembership.ENTITY_NAME)) {
-      log.info("Skipping deprecated record with operation '{}' on '{}.{}'.", recrd.getOperation(),
-          recrd.getSchema(), recrd.getTable());
-      return;
-    }
 
     String schema = recrd.getSchema();
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,7 @@ spring:
   data:
     mongodb:
       uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:sync}?authSource=${AUTH_SOURCE:admin}
+      uuid-representation: standard
   redis:
     host: ${REDIS_HOST:localhost}
     port: ${REDIS_PORT:6379}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfigurationTest.java
@@ -108,13 +108,13 @@ class MongoConfigurationTest {
     verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
 
     List<IndexDefinition> indexes = indexCaptor.getAllValues();
-    assertThat("Unexpected number of indexes.", indexes.size(), is(4));
+    assertThat("Unexpected number of indexes.", indexes.size(), is(3));
 
     List<String> indexKeys = indexes.stream()
         .flatMap(i -> i.getIndexKeys().keySet().stream())
         .collect(Collectors.toList());
     assertThat("Unexpected index.", indexKeys,
-        hasItems("data.programmeId", "data.curriculumId", "data.personId",
-        "data.programmeMembershipType", "data.programmeStartDate", "data.programmeEndDate"));
+        hasItems("programmeId", "personId", "programmeMembershipType", "programmeStartDate",
+            "programmeEndDate"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.sync.event;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -73,7 +74,7 @@ class ProgrammeMembershipEventListenerTest {
 
     listener.onAfterSave(event);
 
-    verify(mockEnricher).enrich(programmeMembership);
+    verify(mockEnricher, never()).enrich(programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 
@@ -121,7 +122,7 @@ class ProgrammeMembershipEventListenerTest {
 
     listener.onAfterDelete(eventAfter);
 
-    verify(mockEnricher).delete(programmeMembership);
+    verify(mockEnricher, never()).delete(programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapperTest.java
@@ -1,0 +1,249 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.mapper;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+
+class ProgrammeMembershipMapperTest {
+
+  private static final String UUID_FIELD = "uuid";
+  private static final UUID UUID_VALUE = UUID.randomUUID();
+  private static final String PM_TYPE_FIELD = "programmeMembershipType";
+  private static final String PM_TYPE_VALUE = "pmType1";
+  private static final String PROGRAMME_START_DATE_FIELD = "programmeStartDate";
+  private static final LocalDate PROGRAMME_START_DATE_VALUE = LocalDate.MIN;
+  private static final String PROGRAMME_END_DATE_FIELD = "programmeEndDate";
+  private static final LocalDate PROGRAMME_END_DATE_VALUE = LocalDate.MAX;
+  private static final String PROGRAMME_ID_FIELD = "programmeId";
+  private static final long PROGRAMME_ID_VALUE = 2;
+  private static final String TRAINING_NUMBER_ID_FIELD = "trainingNumberId";
+  private static final long TRAINING_NUMBER_ID_VALUE = 3;
+  private static final String PERSON_ID_FIELD = "personId";
+  private static final long PERSON_ID_VALUE = 4;
+  private static final String ROTATION_FIELD = "rotation";
+  private static final String ROTATION_VALUE = "rotation5";
+  private static final String ROTATION_ID_FIELD = "rotationId";
+  private static final long ROTATION_ID_VALUE = 6;
+  private static final String TRAINING_PATHWAY_FIELD = "trainingPathway";
+  private static final String TRAINING_PATHWAY_VALUE = "trainingPathway7";
+  private static final String LEAVING_REASON_FIELD = "leavingReason";
+  private static final String LEAVING_REASON_VALUE = "leavingReason8";
+  private static final String LEAVING_DESTINATION_FIELD = "leavingDestination";
+  private static final String LEAVING_DESTINATION_VALUE = "leavingDestination9";
+  private static final String AMENDED_DATE_FIELD = "amendedDate";
+  private static final Instant AMENDED_DATE_VALUE = Instant.EPOCH;
+
+  private ProgrammeMembershipMapper mapper;
+
+  @BeforeEach
+  void setUp() {
+    mapper = new ProgrammeMembershipMapperImpl();
+  }
+
+  @Test
+  void shouldMapPopulatedRecordToProgrammeMembership() {
+    Map<String, String> recordData = Map.ofEntries(
+        Map.entry(UUID_FIELD, UUID_VALUE.toString()),
+        Map.entry(PM_TYPE_FIELD, PM_TYPE_VALUE),
+        Map.entry(PROGRAMME_START_DATE_FIELD, PROGRAMME_START_DATE_VALUE.toString()),
+        Map.entry(PROGRAMME_END_DATE_FIELD, PROGRAMME_END_DATE_VALUE.toString()),
+        Map.entry(PROGRAMME_ID_FIELD, String.valueOf(PROGRAMME_ID_VALUE)),
+        Map.entry(TRAINING_NUMBER_ID_FIELD, String.valueOf(TRAINING_NUMBER_ID_VALUE)),
+        Map.entry(PERSON_ID_FIELD, String.valueOf(PERSON_ID_VALUE)),
+        Map.entry(ROTATION_FIELD, ROTATION_VALUE),
+        Map.entry(ROTATION_ID_FIELD, String.valueOf(ROTATION_ID_VALUE)),
+        Map.entry(TRAINING_PATHWAY_FIELD, TRAINING_PATHWAY_VALUE),
+        Map.entry(LEAVING_REASON_FIELD, LEAVING_REASON_VALUE),
+        Map.entry(LEAVING_DESTINATION_FIELD, LEAVING_DESTINATION_VALUE),
+        Map.entry(AMENDED_DATE_FIELD, AMENDED_DATE_VALUE.toString())
+    );
+
+    ProgrammeMembership programmeMembership = mapper.toEntity(recordData);
+
+    assertThat("Unexpected uuid.", programmeMembership.getUuid(), is(UUID_VALUE));
+    assertThat("Unexpected PM type.", programmeMembership.getProgrammeMembershipType(),
+        is(PM_TYPE_VALUE));
+    assertThat("Unexpected programme start date.", programmeMembership.getProgrammeStartDate(),
+        is(PROGRAMME_START_DATE_VALUE));
+    assertThat("Unexpected programme end date.", programmeMembership.getProgrammeEndDate(),
+        is(PROGRAMME_END_DATE_VALUE));
+    assertThat("Unexpected programme ID.", programmeMembership.getProgrammeId(),
+        is(PROGRAMME_ID_VALUE));
+    assertThat("Unexpected training number ID.", programmeMembership.getTrainingNumberId(),
+        is(TRAINING_NUMBER_ID_VALUE));
+    assertThat("Unexpected person ID.", programmeMembership.getPersonId(), is(PERSON_ID_VALUE));
+    assertThat("Unexpected rotation.", programmeMembership.getRotation(), is(ROTATION_VALUE));
+    assertThat("Unexpected rotation ID.", programmeMembership.getRotationId(),
+        is(ROTATION_ID_VALUE));
+    assertThat("Unexpected training pathway.", programmeMembership.getTrainingPathway(),
+        is(TRAINING_PATHWAY_VALUE));
+    assertThat("Unexpected leaving reason.", programmeMembership.getLeavingReason(),
+        is(LEAVING_REASON_VALUE));
+    assertThat("Unexpected leaving destination.", programmeMembership.getLeavingDestination(),
+        is(LEAVING_DESTINATION_VALUE));
+    assertThat("Unexpected amended date.", programmeMembership.getAmendedDate(),
+        is(AMENDED_DATE_VALUE));
+  }
+
+  @Test
+  void shouldMapNullRecordToProgrammeMembership() {
+    Map<String, String> recordData = new HashMap<>();
+    recordData.put(UUID_FIELD, null);
+    recordData.put(PM_TYPE_FIELD, null);
+    recordData.put(PROGRAMME_START_DATE_FIELD, null);
+    recordData.put(PROGRAMME_END_DATE_FIELD, null);
+    recordData.put(PROGRAMME_ID_FIELD, null);
+    recordData.put(TRAINING_NUMBER_ID_FIELD, null);
+    recordData.put(PERSON_ID_FIELD, null);
+    recordData.put(ROTATION_FIELD, null);
+    recordData.put(ROTATION_ID_FIELD, null);
+    recordData.put(TRAINING_PATHWAY_FIELD, null);
+    recordData.put(LEAVING_REASON_FIELD, null);
+    recordData.put(LEAVING_DESTINATION_FIELD, null);
+    recordData.put(AMENDED_DATE_FIELD, null);
+
+    ProgrammeMembership programmeMembership = mapper.toEntity(recordData);
+
+    assertThat("Unexpected uuid.", programmeMembership.getUuid(), nullValue());
+    assertThat("Unexpected PM type.", programmeMembership.getProgrammeMembershipType(),
+        nullValue());
+    assertThat("Unexpected programme start date.", programmeMembership.getProgrammeStartDate(),
+        nullValue());
+    assertThat("Unexpected programme end date.", programmeMembership.getProgrammeEndDate(),
+        nullValue());
+    assertThat("Unexpected programme ID.", programmeMembership.getProgrammeId(), nullValue());
+    assertThat("Unexpected training number ID.", programmeMembership.getTrainingNumberId(),
+        nullValue());
+    assertThat("Unexpected person ID.", programmeMembership.getPersonId(), nullValue());
+    assertThat("Unexpected rotation.", programmeMembership.getRotation(), nullValue());
+    assertThat("Unexpected rotation ID.", programmeMembership.getRotationId(), nullValue());
+    assertThat("Unexpected training pathway.", programmeMembership.getTrainingPathway(),
+        nullValue());
+    assertThat("Unexpected leaving reason.", programmeMembership.getLeavingReason(), nullValue());
+    assertThat("Unexpected leaving destination.", programmeMembership.getLeavingDestination(),
+        nullValue());
+    assertThat("Unexpected amended date.", programmeMembership.getAmendedDate(), nullValue());
+  }
+
+  @Test
+  void shouldMapPopulatedProgrammeMembershipToRecord() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setUuid(UUID_VALUE);
+    programmeMembership.setProgrammeMembershipType(PM_TYPE_VALUE);
+    programmeMembership.setProgrammeStartDate(PROGRAMME_START_DATE_VALUE);
+    programmeMembership.setProgrammeEndDate(PROGRAMME_END_DATE_VALUE);
+    programmeMembership.setProgrammeId(PROGRAMME_ID_VALUE);
+    programmeMembership.setTrainingNumberId(TRAINING_NUMBER_ID_VALUE);
+    programmeMembership.setPersonId(PERSON_ID_VALUE);
+    programmeMembership.setRotation(ROTATION_VALUE);
+    programmeMembership.setRotationId(ROTATION_ID_VALUE);
+    programmeMembership.setTrainingPathway(TRAINING_PATHWAY_VALUE);
+    programmeMembership.setLeavingReason(LEAVING_REASON_VALUE);
+    programmeMembership.setLeavingDestination(LEAVING_DESTINATION_VALUE);
+    programmeMembership.setAmendedDate(AMENDED_DATE_VALUE);
+
+    Record programmeMembershipRecord = mapper.toRecord(programmeMembership);
+
+    assertThat("Unexpected TIS ID.", programmeMembershipRecord.getTisId(),
+        is(UUID_VALUE.toString()));
+
+    Map<String, String> recordData = programmeMembershipRecord.getData();
+    assertThat("Unexpected uuid.", recordData.get(UUID_FIELD), is(UUID_VALUE.toString()));
+    assertThat("Unexpected PM type.", recordData.get(PM_TYPE_FIELD), is(PM_TYPE_VALUE));
+    assertThat("Unexpected programme start date.", recordData.get(PROGRAMME_START_DATE_FIELD),
+        is(PROGRAMME_START_DATE_VALUE.toString()));
+    assertThat("Unexpected programme end date.", recordData.get(PROGRAMME_END_DATE_FIELD),
+        is(PROGRAMME_END_DATE_VALUE.toString()));
+    assertThat("Unexpected programme ID.", recordData.get(PROGRAMME_ID_FIELD),
+        is(String.valueOf(PROGRAMME_ID_VALUE)));
+    assertThat("Unexpected training number ID.", recordData.get(TRAINING_NUMBER_ID_FIELD),
+        is(String.valueOf(TRAINING_NUMBER_ID_VALUE)));
+    assertThat("Unexpected person ID.", recordData.get(PERSON_ID_FIELD),
+        is(String.valueOf(PERSON_ID_VALUE)));
+    assertThat("Unexpected rotation.", recordData.get(ROTATION_FIELD), is(ROTATION_VALUE));
+    assertThat("Unexpected rotation ID.", recordData.get(ROTATION_ID_FIELD),
+        is(String.valueOf(ROTATION_ID_VALUE)));
+    assertThat("Unexpected training pathway.", recordData.get(TRAINING_PATHWAY_FIELD),
+        is(TRAINING_PATHWAY_VALUE));
+    assertThat("Unexpected leaving reason.", recordData.get(LEAVING_REASON_FIELD),
+        is(LEAVING_REASON_VALUE));
+    assertThat("Unexpected leaving destination.", recordData.get(LEAVING_DESTINATION_FIELD),
+        is(LEAVING_DESTINATION_VALUE));
+    assertThat("Unexpected amended date.", recordData.get(AMENDED_DATE_FIELD),
+        is(AMENDED_DATE_VALUE.toString()));
+    assertThat("Unexpected data count.", recordData.size(), is(13));
+  }
+
+  @Test
+  void shouldMapNullProgrammeMembershipToRecord() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setUuid(null);
+    programmeMembership.setProgrammeMembershipType(null);
+    programmeMembership.setProgrammeStartDate(null);
+    programmeMembership.setProgrammeEndDate(null);
+    programmeMembership.setProgrammeId(null);
+    programmeMembership.setTrainingNumberId(null);
+    programmeMembership.setPersonId(null);
+    programmeMembership.setRotation(null);
+    programmeMembership.setRotationId(null);
+    programmeMembership.setTrainingPathway(null);
+    programmeMembership.setLeavingReason(null);
+    programmeMembership.setLeavingDestination(null);
+    programmeMembership.setAmendedDate(null);
+
+    Record programmeMembershipRecord = mapper.toRecord(programmeMembership);
+
+    assertThat("Unexpected TIS ID.", programmeMembershipRecord.getTisId(), nullValue());
+
+    Map<String, String> recordData = programmeMembershipRecord.getData();
+    assertThat("Unexpected uuid.", recordData.get(UUID_FIELD), nullValue());
+    assertThat("Unexpected PM type.", recordData.get(PM_TYPE_FIELD), nullValue());
+    assertThat("Unexpected programme start date.", recordData.get(PROGRAMME_START_DATE_FIELD),
+        nullValue());
+    assertThat("Unexpected programme end date.", recordData.get(PROGRAMME_END_DATE_FIELD),
+        nullValue());
+    assertThat("Unexpected programme ID.", recordData.get(PROGRAMME_ID_FIELD), nullValue());
+    assertThat("Unexpected training number ID.", recordData.get(TRAINING_NUMBER_ID_FIELD),
+        nullValue());
+    assertThat("Unexpected person ID.", recordData.get(PERSON_ID_FIELD), nullValue());
+    assertThat("Unexpected rotation.", recordData.get(ROTATION_FIELD), nullValue());
+    assertThat("Unexpected rotation ID.", recordData.get(ROTATION_ID_FIELD), nullValue());
+    assertThat("Unexpected training pathway.", recordData.get(TRAINING_PATHWAY_FIELD), nullValue());
+    assertThat("Unexpected leaving reason.", recordData.get(LEAVING_REASON_FIELD), nullValue());
+    assertThat("Unexpected leaving destination.", recordData.get(LEAVING_DESTINATION_FIELD),
+        nullValue());
+    assertThat("Unexpected amended date.", recordData.get(AMENDED_DATE_FIELD), nullValue());
+    assertThat("Unexpected data count.", recordData.size(), is(13));
+  }
+}


### PR DESCRIPTION
Restore the original refactoring that was reverted.
An additional fix has been added for the Redis cache array wrapping issue.

The ObjectMapper configuration was causing the cached values to be
wrapped in an array to provide the class information. The behaviour
should be changed to `As.PROPERTY` to retain the original behaviour.

**Do not deploy without dropping the existing `sync.programmeMembership` collection**

TIS21-4170
TIS21-2399