### PR TITLE
fix: programme membership uuid key

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "0.36.0"
+version = "0.36.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListener.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -72,7 +73,7 @@ public class ProgrammeMembershipEventListener
    */
   @Override
   public void onBeforeDelete(BeforeDeleteEvent<ProgrammeMembership> event) {
-    String id = event.getSource().getString("_id");
+    String id = event.getSource().get("_id", UUID.class).toString();
     ProgrammeMembership programmeMembership =
         programmeMembershipCache.get(id, ProgrammeMembership.class);
     if (programmeMembership == null) {
@@ -87,7 +88,8 @@ public class ProgrammeMembershipEventListener
   public void onAfterDelete(AfterDeleteEvent<ProgrammeMembership> event) {
     super.onAfterDelete(event);
     ProgrammeMembership programmeMembership =
-        programmeMembershipCache.get(event.getSource().getString("_id"), ProgrammeMembership.class);
+        programmeMembershipCache.get(event.getSource().get("_id", UUID.class),
+            ProgrammeMembership.class);
     if (programmeMembership != null) {
       log.info("Skipping enrichment for deprecated ProgrammeMembership type.");
     }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipEventListenerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.UUID;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,8 @@ import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
 
 class ProgrammeMembershipEventListenerTest {
+
+  private static final String uuidString = UUID.randomUUID().toString();
 
   private ProgrammeMembershipEventListener listener;
 
@@ -81,29 +84,29 @@ class ProgrammeMembershipEventListenerTest {
   @Test
   void shouldFindAndCacheProgrammeMembershipIfNotInCacheBeforeDelete() {
     Document document = new Document();
-    document.append("_id", "1");
+    document.append("_id", UUID.fromString(uuidString));
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     BeforeDeleteEvent<ProgrammeMembership> event = new BeforeDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(null);
+    when(mockCache.get(uuidString, ProgrammeMembership.class)).thenReturn(null);
     when(mockProgrammeMembershipSyncService.findById(anyString()))
         .thenReturn(Optional.of(programmeMembership));
 
     listener.onBeforeDelete(event);
 
-    verify(mockProgrammeMembershipSyncService).findById("1");
-    verify(mockCache).put("1", programmeMembership);
+    verify(mockProgrammeMembershipSyncService).findById(uuidString);
+    verify(mockCache).put(uuidString, programmeMembership);
     verifyNoMoreInteractions(mockEnricher);
   }
 
   @Test
   void shouldNotFindAndCacheProgrammeMembershipIfInCacheBeforeDelete() {
     Document document = new Document();
-    document.append("_id", "1");
+    document.append("_id", UUID.fromString(uuidString));
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     BeforeDeleteEvent<ProgrammeMembership> event = new BeforeDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(programmeMembership);
+    when(mockCache.get(uuidString, ProgrammeMembership.class)).thenReturn(programmeMembership);
 
     listener.onBeforeDelete(event);
 
@@ -114,11 +117,11 @@ class ProgrammeMembershipEventListenerTest {
   @Test
   void shouldCallFacadeDeleteAfterDelete() {
     Document document = new Document();
-    document.append("_id", "1");
+    document.append("_id", UUID.fromString(uuidString));
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     AfterDeleteEvent<ProgrammeMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(programmeMembership);
+    when(mockCache.get(uuidString, ProgrammeMembership.class)).thenReturn(programmeMembership);
 
     listener.onAfterDelete(eventAfter);
 
@@ -129,10 +132,10 @@ class ProgrammeMembershipEventListenerTest {
   @Test
   void shouldNotCallFacadeDeleteIfNoProgrammeMembership() {
     Document document = new Document();
-    document.append("_id", "1");
+    document.append("_id", UUID.fromString(uuidString));
     AfterDeleteEvent<ProgrammeMembership> eventAfter = new AfterDeleteEvent<>(document, null, null);
 
-    when(mockCache.get("1", ProgrammeMembership.class)).thenReturn(null);
+    when(mockCache.get(uuidString, ProgrammeMembership.class)).thenReturn(null);
 
     listener.onAfterDelete(eventAfter);
 


### PR DESCRIPTION
Example error logs for programme membership deletions:

2023-06-07 07:29:35.889 ERROR 1 --- [nerContainer-37]
i.a.c.m.listener.QueueMessageHandler     : An exception occurred while
invoking the handler method
java.lang.ClassCastException: class java.util.UUID cannot be cast to
class java.lang.String (java.util.UUID and java.lang.String are in
module java.base of loader 'bootstrap')
	at org.bson.Document.getString(Document.java:306)
	~[bson-4.6.1.jar:na]
		at
		uk.nhs.hee.tis.trainee.sync.event.ProgrammeMembershipEventListener.onBeforeDelete(ProgrammeMembershipEventListener.java:75)
		~[classes/:na]
NO-TICKET