### PR TITLE
fix: add missing PM queue listener

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.0.1"
+version = "1.0.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListener.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy.ON_SUCCESS;
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
+
+/**
+ * A listener for Programme Membership messages.
+ */
+@Slf4j
+@Component
+public class ProgrammeMembershipListener {
+
+  private final ProgrammeMembershipSyncService programmeMembershipService;
+
+  ProgrammeMembershipListener(ProgrammeMembershipSyncService programmeMembershipService) {
+    this.programmeMembershipService = programmeMembershipService;
+  }
+
+  /**
+   * Listen for programme membership records and call the enricher.
+   *
+   * @param programmeMembership The programme membership to enrich.
+   */
+  @SqsListener(value = "${application.aws.sqs.programme-membership}", deletionPolicy = ON_SUCCESS)
+  void getProgrammeMembership(Record programmeMembership) {
+    log.debug("Received programme membership {}.", programmeMembership);
+    programmeMembershipService.syncProgrammeMembership(programmeMembership);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingProgrammeMembershipIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingProgrammeMembershipIntTest.java
@@ -124,7 +124,7 @@ class CachingProgrammeMembershipIntTest {
     programmeMembershipSyncService.findById(PROGRAMME_MEMBERSHIP_ID.toString());
     assertThat(programmeMembershipCache.get(PROGRAMME_MEMBERSHIP_ID)).isNotNull();
 
-    programmeMembershipSyncService.syncRecord(programmeMembershipRecord);
+    programmeMembershipSyncService.syncProgrammeMembership(programmeMembershipRecord);
     assertThat(programmeMembershipCache.get(PROGRAMME_MEMBERSHIP_ID)).isNull();
     assertThat(programmeMembershipCache.get(otherKey)).isNotNull();
     verify(mockProgrammeMembershipRepository).deleteById(PROGRAMME_MEMBERSHIP_ID);
@@ -151,7 +151,7 @@ class CachingProgrammeMembershipIntTest {
 
     when(mockProgrammeMembershipRepository.save(staleProgrammeMembership))
         .thenReturn(staleProgrammeMembership);
-    programmeMembershipSyncService.syncRecord(staleProgrammeMembershipRecord);
+    programmeMembershipSyncService.syncProgrammeMembership(staleProgrammeMembershipRecord);
     assertThat(programmeMembershipCache.get(PROGRAMME_MEMBERSHIP_ID).get())
         .isEqualTo(staleProgrammeMembership);
 
@@ -169,7 +169,7 @@ class CachingProgrammeMembershipIntTest {
     when(mockProgrammeMembershipRepository.save(updatedProgrammeMembership))
         .thenReturn(updatedProgrammeMembership);
 
-    programmeMembershipSyncService.syncRecord(updateProgrammeMembershipRecord);
+    programmeMembershipSyncService.syncProgrammeMembership(updateProgrammeMembershipRecord);
     assertThat(programmeMembershipCache.get(PROGRAMME_MEMBERSHIP_ID).get())
         .isEqualTo(updatedProgrammeMembership);
     verify(mockProgrammeMembershipRepository).save(staleProgrammeMembership);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListenerTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
+
+class ProgrammeMembershipListenerTest {
+
+  private ProgrammeMembershipListener listener;
+
+  private ProgrammeMembershipSyncService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(ProgrammeMembershipSyncService.class);
+    listener = new ProgrammeMembershipListener(service);
+  }
+
+  @Test
+  void shouldProcessRecordWhenDataAndMetadataNotNull() {
+    Placement placement = new Placement();
+    placement.setData(Collections.emptyMap());
+    placement.setMetadata(Collections.emptyMap());
+
+    listener.getProgrammeMembership(placement);
+
+    verify(service).syncProgrammeMembership(placement);
+  }
+}


### PR DESCRIPTION
The programme membership sync queue is populated by Programme and CurriculumMembership services, but the SQS listener is missing. Create the SQS listener to read from the PM queue and perform deletions/enrichment.

A slight divergence to the typical pattern is needed, as we can no longer check if the Record is an instance of ProgrammeMembership. Check the record's table instead.

TIS21-2399
TIS21-4172