### PR TITLE
test: create record instead of placement

### DIFF
--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeMembershipListenerTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.verify;
 import java.util.Collections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
 
 class ProgrammeMembershipListenerTest {
@@ -44,12 +44,12 @@ class ProgrammeMembershipListenerTest {
 
   @Test
   void shouldProcessRecordWhenDataAndMetadataNotNull() {
-    Placement placement = new Placement();
-    placement.setData(Collections.emptyMap());
-    placement.setMetadata(Collections.emptyMap());
+    Record programmeMembership = new Record();
+    programmeMembership.setData(Collections.emptyMap());
+    programmeMembership.setMetadata(Collections.emptyMap());
 
-    listener.getProgrammeMembership(placement);
+    listener.getProgrammeMembership(programmeMembership);
 
-    verify(service).syncProgrammeMembership(placement);
+    verify(service).syncProgrammeMembership(programmeMembership);
   }
 }


### PR DESCRIPTION
The programme membership listener tests create an instance of Placement instead of Record. This doesn't break the test but isn't a correct reflection of the expectation.

TIS21-2399