### PR TITLE
fix: record uuid should not overwrite TIS ID.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.0.2"
+version = "1.0.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
@@ -52,7 +52,7 @@ public interface RecordMapper {
   @AfterMapping
   default void setTisIdFromUuid(RecordDto sourceDto, @MappingTarget Record target) {
     String theUuid = sourceDto.getData().get("uuid");
-    if (theUuid != null) {
+    if (target.getTisId() == null && theUuid != null) {
       target.setTisId(theUuid);
     }
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
@@ -63,7 +63,7 @@ class RecordMapperTest {
   }
 
   @Test
-  void shouldPreferentiallyMapRecordDtoUuidToRecordTisId() {
+  void shouldPreferentiallyMapRecordDtoTisIdToRecordTisId() {
     Map<String, String> recordData = Map.ofEntries(
         Map.entry(ID_FIELD, ID_VALUE),
         Map.entry(UUID_FIELD, UUID_VALUE)
@@ -73,11 +73,11 @@ class RecordMapperTest {
     recordDto.setMetadata(recordMetadata);
 
     Record record = mapper.toEntity(recordDto);
-    assertThat("Unexpected tisId.", record.getTisId(), is(UUID_VALUE));
+    assertThat("Unexpected tisId.", record.getTisId(), is(ID_VALUE));
   }
 
   @Test
-  void shouldMapRecordDtoIdToRecordTisId() {
+  void shouldMapRecordDtoIdToRecordTisIdWhenOnlyTisId() {
     Map<String, String> recordData = Map.ofEntries(
         Map.entry(ID_FIELD, ID_VALUE)
     );
@@ -87,5 +87,18 @@ class RecordMapperTest {
 
     Record record = mapper.toEntity(recordDto);
     assertThat("Unexpected tisId.", record.getTisId(), is(ID_VALUE));
+  }
+
+  @Test
+  void shouldMapRecordDtoUuidToRecordTisIdWhenOnlyUuid() {
+    Map<String, String> recordData = Map.ofEntries(
+        Map.entry(UUID_FIELD, UUID_VALUE)
+    );
+    RecordDto recordDto = new RecordDto();
+    recordDto.setData(recordData);
+    recordDto.setMetadata(recordMetadata);
+
+    Record record = mapper.toEntity(recordDto);
+    assertThat("Unexpected tisId.", record.getTisId(), is(UUID_VALUE));
   }
 }


### PR DESCRIPTION
When performing a record mapping, the `tisId` field is being overwritten if a UUID exists in the data.
The UUID should only be populated in to the `tisId` field if no other value is available (i.e. `tisId` is `null`).

TIS21-2399