### PR TITLE
fix: set message group ID for SNS publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.1.0"
+version = "1.1.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -186,6 +186,13 @@ public class TcsSyncService implements SyncService {
         request = new PublishRequest()
             .withMessage(eventJson.toString())
             .withTopicArn(snsTopic);
+
+        if (snsTopic.endsWith(".fifo")) {
+          // Create a message group to ensure FIFO per unique object.
+          String messageGroup = String.format("%s_%s_%s", recrd.getSchema(), recrd.getTable(),
+              recrd.getTisId());
+          request.setMessageGroupId(messageGroup);
+        }
       }
     }
 


### PR DESCRIPTION
When pubishing to a FIFO SNS topic the Message Group ID must be set, this defines which groups of messages must be procesed in order. Create an ID for FIFO publishing which uses the schema, table and record ID to ensure that all messages for the same data record are processed in order. Taking this approach rather than having every message be in the same group ensure that we can be efficient and not block updates that can be handled in parallel.

TIS21-4085
TIS21-4076