### PR TITLE
feat: disable personal details update API calls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.1.2"
+version = "1.2.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -267,9 +267,7 @@ public class TcsSyncService implements SyncService {
       case INSERT, LOAD, UPDATE ->
           restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, dto, Object.class, apiPath,
               dto.getTraineeTisId());
-      case DELETE -> {
-        deleteDetails(dto, apiPath);
-      }
+      case DELETE -> deleteDetails(dto, apiPath);
       default -> log.warn("Unhandled record operation {}.", operationType);
     }
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -65,13 +65,15 @@ public class TcsSyncService implements SyncService {
   private static final String TABLE_CURRICULUM_MEMBERSHIP = "CurriculumMembership";
   private static final String TABLE_CURRICULUM = "Curriculum";
 
+  // Some API endpoints have been replaced with message queues.
+  private static final String DISABLED = "DISABLED";
   private static final Map<String, String> TABLE_NAME_TO_API_PATH = Map.ofEntries(
-      Map.entry(TABLE_CONTACT_DETAILS, "contact-details"),
-      Map.entry(TABLE_GDC_DETAILS, "gdc-details"),
-      Map.entry(TABLE_GMC_DETAILS, "gmc-details"),
+      Map.entry(TABLE_CONTACT_DETAILS, DISABLED),
+      Map.entry(TABLE_GDC_DETAILS, DISABLED),
+      Map.entry(TABLE_GMC_DETAILS, DISABLED),
       Map.entry(TABLE_PERSON, "basic-details"),
-      Map.entry(TABLE_PERSON_OWNER, "person-owner"),
-      Map.entry(TABLE_PERSONAL_DETAILS, "personal-info"),
+      Map.entry(TABLE_PERSON_OWNER, DISABLED),
+      Map.entry(TABLE_PERSONAL_DETAILS, DISABLED),
       Map.entry(TABLE_QUALIFICATION, "qualification"),
       Map.entry(TABLE_PLACEMENT, "placement"),
       Map.entry(TABLE_PROGRAMME_MEMBERSHIP, "programme-membership"),
@@ -172,7 +174,8 @@ public class TcsSyncService implements SyncService {
       // record change should be broadcast
       Map<String, Object> treeValues = switch (recrd.getOperation()) {
         case DELETE -> Map.of(
-            "tisId", recrd.getTisId()
+            "tisId", recrd.getTisId(),
+            "record", new Record()
         );
         case INSERT, LOAD, UPDATE -> Map.of(
             "tisId", recrd.getTisId(),
@@ -217,6 +220,12 @@ public class TcsSyncService implements SyncService {
   private String tableToSnsTopic(String table, Operation operation) {
     return switch (operation) {
       case DELETE -> switch (table) {
+        // Personal Details deletes are treated as an empty update.
+        case TABLE_CONTACT_DETAILS -> eventNotificationProperties.updateContactDetails();
+        case TABLE_GDC_DETAILS -> eventNotificationProperties.updateGdcDetails();
+        case TABLE_GMC_DETAILS -> eventNotificationProperties.updateGmcDetails();
+        case TABLE_PERSONAL_DETAILS -> eventNotificationProperties.updatePersonalInfo();
+        case TABLE_PERSON_OWNER -> eventNotificationProperties.updatePersonOwner();
         case TABLE_PLACEMENT -> eventNotificationProperties.deletePlacementEvent();
         case TABLE_PROGRAMME_MEMBERSHIP, TABLE_CURRICULUM_MEMBERSHIP ->
             eventNotificationProperties.deleteProgrammeMembershipEvent();
@@ -226,7 +235,6 @@ public class TcsSyncService implements SyncService {
         case TABLE_CONTACT_DETAILS -> eventNotificationProperties.updateContactDetails();
         case TABLE_GDC_DETAILS -> eventNotificationProperties.updateGdcDetails();
         case TABLE_GMC_DETAILS -> eventNotificationProperties.updateGmcDetails();
-        case TABLE_PERSON -> eventNotificationProperties.updatePerson();
         case TABLE_PERSONAL_DETAILS -> eventNotificationProperties.updatePersonalInfo();
         case TABLE_PERSON_OWNER -> eventNotificationProperties.updatePersonOwner();
         case TABLE_PLACEMENT -> eventNotificationProperties.updatePlacementEvent();
@@ -250,16 +258,19 @@ public class TcsSyncService implements SyncService {
    * @param operationType The operation type of the record being synchronized.
    */
   private void syncDetails(TraineeDetailsDto dto, String apiPath, Operation operationType) {
+    if (apiPath.equals(DISABLED)) {
+      log.debug("API call skipped, as message already dispatched.");
+      return;
+    }
+
     switch (operationType) {
-      case INSERT, LOAD, UPDATE:
-        restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, dto, Object.class, apiPath,
-            dto.getTraineeTisId());
-        break;
-      case DELETE:
+      case INSERT, LOAD, UPDATE ->
+          restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, dto, Object.class, apiPath,
+              dto.getTraineeTisId());
+      case DELETE -> {
         deleteDetails(dto, apiPath);
-        break;
-      default:
-        log.warn("Unhandled record operation {}.", operationType);
+      }
+      default -> log.warn("Unhandled record operation {}.", operationType);
     }
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -152,7 +152,6 @@ class TcsSyncServiceTest {
     ReflectionUtils.setField(field, mapper, new TraineeDetailsUtil());
 
     objectMapper = new ObjectMapper();
-//    objectMapper.registerModule(new JavaTimeModule());
 
     restTemplate = mock(RestTemplate.class);
     personService = mock(PersonService.class);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -47,6 +47,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.AmazonSNSException;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
@@ -136,6 +137,8 @@ class TcsSyncServiceTest {
 
   private TraineeDetailsMapper mapper;
 
+  private ObjectMapper objectMapper;
+
   private Map<String, String> data;
 
   private Record recrd;
@@ -147,6 +150,9 @@ class TcsSyncServiceTest {
     assert field != null;
     field.setAccessible(true);
     ReflectionUtils.setField(field, mapper, new TraineeDetailsUtil());
+
+    objectMapper = new ObjectMapper();
+//    objectMapper.registerModule(new JavaTimeModule());
 
     restTemplate = mock(RestTemplate.class);
     personService = mock(PersonService.class);
@@ -312,9 +318,9 @@ class TcsSyncServiceTest {
   }
 
   @ParameterizedTest(
-      name = "Should patch contact details when operation is {0} and table is ContactDetails")
+      name = "Should update contact details when operation is {0} and table is ContactDetails")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
-  void shouldPatchContactDetails(Operation operation) {
+  void shouldUpdateContactDetails(Operation operation) throws JsonProcessingException {
     recrd.setTable("ContactDetails");
     recrd.setOperation(operation);
     recrd.setData(data);
@@ -325,34 +331,33 @@ class TcsSyncServiceTest {
 
     service.syncRecord(recrd);
 
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setTitle("titleValue");
-      expectedDto.setForenames("forenamesValue");
-      expectedDto.setKnownAs("knownAsValue");
-      expectedDto.setSurname("surnameValue");
-      expectedDto.setMaidenName("maidenNameValue");
-      expectedDto.setTelephoneNumber("telephoneNumberValue");
-      expectedDto.setMobileNumber("mobileNumberValue");
-      expectedDto.setEmail("emailValue");
-      expectedDto.setAddress1("address1Value");
-      expectedDto.setAddress2("address2Value");
-      expectedDto.setAddress3("address3Value");
-      expectedDto.setAddress4("address4Value");
-      expectedDto.setPostCode("postCodeValue");
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsService).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.getTopicArn(),
+        is(UPDATE_CONTACT_DETAILS_EVENT_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.getMessage(),
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected TIS ID.", message.get("tisId"), is("idValue"));
+
+    Record messageRecord = objectMapper.convertValue(message.get("record"), Record.class);
+    if (operation.equals(DELETE)) {
+      assertThat("Unexpected record.", messageRecord, is(new Record()));
+    } else {
+      assertThat("Unexpected record.", messageRecord, is(recrd));
     }
 
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("contact-details"),
-            eq("idValue"));
-    verifyNoMoreInteractions(restTemplate);
+    verifyNoMoreInteractions(snsService);
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(
-      name = "Should patch GDC details when operation is {0} and table is GdcDetails")
+      name = "Should update GDC details when operation is {0} and table is GdcDetails")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
-  void shouldPatchGdcDetails(Operation operation) {
+  void shouldUpdateGdcDetails(Operation operation) throws JsonProcessingException {
     Map<String, String> data = new HashMap<>();
     data.put("gdcNumber", "gdcNumberValue");
     data.put("gdcStatus", "gdcStatusValue");
@@ -367,23 +372,32 @@ class TcsSyncServiceTest {
 
     service.syncRecord(recrd);
 
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setGdcNumber("gdcNumberValue");
-      expectedDto.setGdcStatus("gdcStatusValue");
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsService).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.getTopicArn(), is(UPDATE_GDC_DETAILS_EVENT_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.getMessage(),
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected TIS ID.", message.get("tisId"), is("idValue"));
+
+    Record messageRecord = objectMapper.convertValue(message.get("record"), Record.class);
+    if (operation.equals(DELETE)) {
+      assertThat("Unexpected record.", messageRecord, is(new Record()));
+    } else {
+      assertThat("Unexpected record.", messageRecord, is(recrd));
     }
 
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("gdc-details"),
-            eq("idValue"));
-    verifyNoMoreInteractions(restTemplate);
+    verifyNoMoreInteractions(snsService);
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(
-      name = "Should patch GMC details when operation is {0} and table is GmcDetails")
+      name = "Should update GMC details when operation is {0} and table is GmcDetails")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
-  void shouldPatchGmcDetails(Operation operation) {
+  void shouldUpdateGmcDetails(Operation operation) throws JsonProcessingException {
     Map<String, String> data = new HashMap<>();
     data.put("gmcNumber", "gmcNumberValue");
     data.put("gmcStatus", "gmcStatusValue");
@@ -398,23 +412,32 @@ class TcsSyncServiceTest {
 
     service.syncRecord(recrd);
 
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setGmcNumber("gmcNumberValue");
-      expectedDto.setGmcStatus("gmcStatusValue");
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsService).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.getTopicArn(), is(UPDATE_GMC_DETAILS_EVENT_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.getMessage(),
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected TIS ID.", message.get("tisId"), is("idValue"));
+
+    Record messageRecord = objectMapper.convertValue(message.get("record"), Record.class);
+    if (operation.equals(DELETE)) {
+      assertThat("Unexpected record.", messageRecord, is(new Record()));
+    } else {
+      assertThat("Unexpected record.", messageRecord, is(recrd));
     }
 
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("gmc-details"),
-            eq("idValue"));
-    verifyNoMoreInteractions(restTemplate);
+    verifyNoMoreInteractions(snsService);
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(
-      name = "Should patch person owner when operation is {0} and table is PersonOwner")
+      name = "Should update person owner when operation is {0} and table is PersonOwner")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
-  void shouldPatchPersonOwnerInfo(Operation operation) {
+  void shouldUpdatePersonOwnerInfo(Operation operation) throws JsonProcessingException {
     Map<String, String> data = new HashMap<>();
     data.put("owner", "personOwnerValue");
 
@@ -428,22 +451,32 @@ class TcsSyncServiceTest {
 
     service.syncRecord(recrd);
 
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setPersonOwner("personOwnerValue");
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsService).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.getTopicArn(), is(UPDATE_PERSON_OWNER_EVENT_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.getMessage(),
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected TIS ID.", message.get("tisId"), is("idValue"));
+
+    Record messageRecord = objectMapper.convertValue(message.get("record"), Record.class);
+    if (operation.equals(DELETE)) {
+      assertThat("Unexpected record.", messageRecord, is(new Record()));
+    } else {
+      assertThat("Unexpected record.", messageRecord, is(recrd));
     }
 
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("person-owner"),
-            eq("idValue"));
-    verifyNoMoreInteractions(restTemplate);
+    verifyNoMoreInteractions(snsService);
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(
-      name = "Should patch personal info when operation is {0} and table is PersonalDetails")
+      name = "Should update personal info when operation is {0} and table is PersonalDetails")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE", "DELETE"})
-  void shouldPatchPersonalInfo(Operation operation) {
+  void shouldUpdatePersonalInfo(Operation operation) throws JsonProcessingException {
     Map<String, String> data = new HashMap<>();
     data.put("dateOfBirth", "1978-03-23");
     data.put("gender", "genderValue");
@@ -457,17 +490,26 @@ class TcsSyncServiceTest {
 
     service.syncRecord(recrd);
 
-    TraineeDetailsDto expectedDto = new TraineeDetailsDto();
-    if (!operation.equals(DELETE)) {
-      expectedDto.setTraineeTisId("idValue");
-      expectedDto.setDateOfBirth("1978-03-23");
-      expectedDto.setGender("genderValue");
+    ArgumentCaptor<PublishRequest> requestCaptor = ArgumentCaptor.forClass(PublishRequest.class);
+    verify(snsService).publish(requestCaptor.capture());
+
+    PublishRequest request = requestCaptor.getValue();
+    assertThat("Unexpected topic ARN.", request.getTopicArn(), is(UPDATE_PERSONAL_INFO_EVENT_ARN));
+
+    Map<String, Object> message = objectMapper.readValue(request.getMessage(),
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected TIS ID.", message.get("tisId"), is("idValue"));
+
+    Record messageRecord = objectMapper.convertValue(message.get("record"), Record.class);
+    if (operation.equals(DELETE)) {
+      assertThat("Unexpected record.", messageRecord, is(new Record()));
+    } else {
+      assertThat("Unexpected record.", messageRecord, is(recrd));
     }
 
-    verify(restTemplate)
-        .patchForObject(anyString(), eq(expectedDto), eq(Object.class), eq("personal-info"),
-            eq("idValue"));
-    verifyNoMoreInteractions(restTemplate);
+    verifyNoMoreInteractions(snsService);
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(
@@ -617,9 +659,8 @@ class TcsSyncServiceTest {
    */
   private static Stream<Arguments> provideUpdateParameters() {
     return Stream.of(UPDATE, LOAD, INSERT).flatMap(operation ->
-        Stream.of(TABLE_CONTACT_DETAILS, TABLE_GDC_DETAILS, TABLE_GMC_DETAILS, TABLE_PERSON,
-                TABLE_PERSON_OWNER, TABLE_PERSONAL_DETAILS, TABLE_PLACEMENT,
-                TABLE_PROGRAMME_MEMBERSHIP)
+        Stream.of(TABLE_CONTACT_DETAILS, TABLE_GDC_DETAILS, TABLE_GMC_DETAILS, TABLE_PERSON_OWNER,
+                TABLE_PERSONAL_DETAILS, TABLE_PLACEMENT, TABLE_PROGRAMME_MEMBERSHIP)
             .flatMap(table -> Stream.of(
                 Arguments.of(operation, table)
             ))
@@ -831,8 +872,7 @@ class TcsSyncServiceTest {
 
   @ParameterizedTest(
       name = "Should throw error when trainee patch returns an error and table is {0}")
-  @ValueSource(strings = {"ContactDetails", "GdcDetails", "GmcDetails", "Person", "PersonOwner",
-      "PersonalDetails", "Qualification"})
+  @ValueSource(strings = {"Person", "Qualification"})
   void shouldThrowErrorWhenNon404ErrorForDetails(String tableName) {
     recrd.setTable(tableName);
     recrd.setOperation(UPDATE);


### PR DESCRIPTION
Personal details updates are now handled by messaging and the API endpoints are to be removed. Disable to the calls to those API endpoints.

`Person`/`basic-details` being emitted as an event has been rolled back due to additional behaviour that needs to be account for, specifically the deletion of the trainee profile.

TIS21-4085
TIS21-4076