### PR TITLE
Feat/enrich other placement sites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.2.1"
+version = "1.3.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -78,6 +78,7 @@ public class TraineeDetailsDto {
   private String site;
   private String siteLocation;
   private String siteKnownAs;
+  private Set<Map<String, String>> otherSites;
   private String grade;
   private String specialty;
   private String placementType;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/PlacementSiteMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/PlacementSiteMapper.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.mapper;
+
+import java.util.Map;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants.ComponentModel;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+
+/**
+ * A mapper to convert between PlacementSite data types.
+ */
+@Mapper(componentModel = ComponentModel.SPRING)
+public interface PlacementSiteMapper {
+
+  /**
+   * Map a record data map to a PlacementSite.
+   *
+   * @param recordData The map to convert.
+   * @return The mapped PlacementSite.
+   */
+  PlacementSite toEntity(Map<String, String> recordData);
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -27,6 +27,7 @@ import org.mapstruct.ReportingPolicy;
 import uk.nhs.hee.tis.trainee.sync.dto.TraineeDetailsDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.Curricula;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.OtherSites;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 
 @Mapper(componentModel = "spring", uses = TraineeDetailsUtil.class,
@@ -95,6 +96,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "site", source = "data.site")
   @Mapping(target = "siteLocation", source = "data.siteLocation")
   @Mapping(target = "siteKnownAs", source = "data.siteKnownAs")
+  @Mapping(target = "otherSites", source = "data", qualifiedBy = OtherSites.class)
   @Mapping(target = "specialty", source = "data.specialty")
   @Mapping(target = "wholeTimeEquivalent", source = "data.placementWholeTimeEquivalent")
   TraineeDetailsDto toPlacementDto(Record recrd);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
@@ -46,6 +46,13 @@ public class TraineeDetailsUtil {
 
   }
 
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface OtherSites {
+
+  }
+
   /**
    * Gets the set of curricula from the data map String.
    *
@@ -54,7 +61,6 @@ public class TraineeDetailsUtil {
    */
   @Curricula
   public Set<Map<String, String>> curricula(Map<String, String> data) {
-
     ObjectMapper mapper = new ObjectMapper();
 
     Set<Map<String, String>> curricula = new HashSet<>();
@@ -68,5 +74,28 @@ public class TraineeDetailsUtil {
     }
 
     return curricula;
+  }
+
+  /**
+   * Gets the set of other sites from the data map String.
+   *
+   * @param data the data containing the other sites as a string
+   * @return the other sites
+   */
+  @OtherSites
+  public Set<Map<String, String>> otherSites(Map<String, String> data) {
+    ObjectMapper mapper = new ObjectMapper();
+
+    Set<Map<String, String>> otherSites = new HashSet<>();
+    if (data.get("otherSites") != null) {
+      try {
+        otherSites = mapper.readValue(data.get("otherSites"), new TypeReference<>() {
+        });
+      } catch (JsonProcessingException e) {
+        log.error("Badly formed other sites JSON in {}", data);
+      }
+    }
+
+    return otherSites;
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSite.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSite.java
@@ -22,14 +22,19 @@
 package uk.nhs.hee.tis.trainee.sync.model;
 
 import lombok.Data;
+import org.springframework.data.annotation.Id;
 
+/**
+ * An entity representation of a TIS PlacementSite.
+ */
 @Data
 public class PlacementSite {
 
   public static final String ENTITY_NAME = "PlacementSite";
 
-  private final Long id;
-  private final Long placementId;
-  private final Long siteId;
-  private final String placementSiteType;
+  @Id
+  private Long id;
+  private Long placementId;
+  private Long siteId;
+  private String placementSiteType;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSite.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSite.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.model;
+
+import lombok.Data;
+
+@Data
+public class PlacementSite {
+
+  public static final String ENTITY_NAME = "PlacementSite";
+
+  private final Long id;
+  private final Long placementId;
+  private final Long siteId;
+  private final String placementSiteType;
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
@@ -21,11 +21,21 @@
 
 package uk.nhs.hee.tis.trainee.sync.repository;
 
+import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 
 @Repository
 public interface PlacementSiteRepository extends MongoRepository<PlacementSite, Long> {
 
+  /**
+   * Find PlacementSites with the OTHER type for the given placement.
+   *
+   * @param placementId The placement ID to filter by.
+   * @return The found PlacementSites, empty if no results.
+   */
+  @Query("{ $and: [ {'placementId' : ?0}, { 'placementSiteType' : \"OTHER\"} ] }")
+  Set<PlacementSite> findOtherSitesByPlacementId(long placementId);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+
+@Repository
+public interface PlacementSiteRepository extends MongoRepository<PlacementSite, Long> {
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.sync.service;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import java.util.Objects;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.mapper.PlacementSiteMapper;
@@ -57,5 +58,15 @@ public class PlacementSiteSyncService implements SyncService {
     } else {
       repository.save(placementSite);
     }
+  }
+
+  /**
+   * Find PlacementSites with the OTHER type for the given placement.
+   *
+   * @param placementId The placement ID to filter by.
+   * @return The found PlacementSites, empty if no results.
+   */
+  public Set<PlacementSite> findOtherSitesByPlacementId(long placementId) {
+    return repository.findOtherSitesByPlacementId(placementId);
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.mapper.PlacementSiteMapper;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.PlacementSiteRepository;
+
+@Slf4j
+@Service("tcs-PlacementSite")
+public class PlacementSiteSyncService implements SyncService {
+
+  private final PlacementSiteRepository repository;
+  private final PlacementSiteMapper mapper;
+
+  PlacementSiteSyncService(PlacementSiteRepository repository, PlacementSiteMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public void syncRecord(Record placementSiteRecord) {
+    if (!Objects.equals(placementSiteRecord.getTable(), PlacementSite.ENTITY_NAME)) {
+      String message = String.format("Invalid record type '%s'.", placementSiteRecord.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    PlacementSite placementSite = mapper.toEntity(placementSiteRecord.getData());
+
+    if (placementSiteRecord.getOperation().equals(DELETE)) {
+      repository.deleteById(placementSite.getId());
+    } else {
+      repository.save(placementSite);
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
@@ -1,22 +1,22 @@
 /*
  * The MIT License (MIT)
  *
- *  Copyright 2023 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- *  associated documentation files (the "Software"), to deal in the Software without restriction,
- *  including without limitation the rights to use, copy, modify, merge, publish, distribute,
- *  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in all copies or
- *  substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- *  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- *  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package uk.nhs.hee.tis.trainee.sync.mapper;

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
@@ -65,4 +65,24 @@ class TraineeDetailsMapperTest {
 
     assertThat("Unexpected curricula size.", traineeDetails.getCurricula().size(), is(0));
   }
+
+  @Test
+  void shouldMapOtherSitesToEmptySetWhenBadJson() {
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("otherSites", "bad JSON"));
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected curricula size.", traineeDetails.getOtherSites().size(), is(0));
+  }
+
+  @Test
+  void shouldMapOtherSitesToEmptySetWhenMissing() {
+    Record recrd = new Record();
+    recrd.setData(Collections.singletonMap("otherSites", null));
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected curricula size.", traineeDetails.getOtherSites().size(), is(0));
+  }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import uk.nhs.hee.tis.trainee.sync.mapper.PlacementSiteMapper;
+import uk.nhs.hee.tis.trainee.sync.mapper.PlacementSiteMapperImpl;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.PlacementSiteRepository;
+
+class PlacementSiteSyncServiceTest {
+
+  private static final Long ID = 1L;
+  private static final Long PLACEMENT_ID = 2L;
+  private static final Long SITE_ID = 3L;
+  private static final String TYPE = "OTHER";
+
+  private PlacementSiteSyncService service;
+  private PlacementSiteRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(PlacementSiteRepository.class);
+    PlacementSiteMapper mapper = new PlacementSiteMapperImpl();
+    service = new PlacementSiteSyncService(repository, mapper);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotSite() {
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
+  }
+
+  @ParameterizedTest(name = "Should store records when operation is {0}.")
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  void shouldStoreRecords(Operation operation) {
+    Record placementSiteRecord = new Record();
+    placementSiteRecord.setOperation(operation);
+    placementSiteRecord.setTable(PlacementSite.ENTITY_NAME);
+    placementSiteRecord.setData(Map.of(
+        "id", ID.toString(),
+        "placementId", PLACEMENT_ID.toString(),
+        "siteId", SITE_ID.toString(),
+        "placementSiteType", TYPE
+    ));
+
+    service.syncRecord(placementSiteRecord);
+
+    ArgumentCaptor<PlacementSite> captor = ArgumentCaptor.forClass(PlacementSite.class);
+    verify(repository).save(captor.capture());
+
+    PlacementSite placementSite = captor.getValue();
+    assertThat("Unexpected ID.", placementSite.getId(), is(ID));
+    assertThat("Unexpected placement ID.", placementSite.getPlacementId(), is(PLACEMENT_ID));
+    assertThat("Unexpected site ID.", placementSite.getSiteId(), is(SITE_ID));
+    assertThat("Unexpected site type.", placementSite.getPlacementSiteType(), is(TYPE));
+
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeleteRecordFromStore() {
+    Record placementSiteRecord = new Record();
+    placementSiteRecord.setOperation(DELETE);
+    placementSiteRecord.setTable(PlacementSite.ENTITY_NAME);
+    placementSiteRecord.setData(Map.of(
+        "id", ID.toString()
+    ));
+
+    service.syncRecord(placementSiteRecord);
+
+    verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
@@ -22,14 +22,18 @@
 package uk.nhs.hee.tis.trainee.sync.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -104,6 +108,34 @@ class PlacementSiteSyncServiceTest {
     service.syncRecord(placementSiteRecord);
 
     verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindOtherSiteByPlacementIdWhenExists() {
+    PlacementSite placementSite = new PlacementSite();
+    when(repository.findOtherSitesByPlacementId(ID)).thenReturn(
+        Collections.singleton(placementSite));
+
+    Set<PlacementSite> foundRecords = service.findOtherSitesByPlacementId(ID);
+    assertThat("Unexpected other site count.", foundRecords.size(), is(1));
+
+    PlacementSite foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected other site.", foundRecord, sameInstance(placementSite));
+
+    verify(repository).findOtherSitesByPlacementId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindOtherSiteByPlacementIdWhenNotExists() {
+    when(repository.findOtherSitesByPlacementId(ID))
+        .thenReturn(Collections.emptySet());
+
+    Set<PlacementSite> foundRecords = service.findOtherSitesByPlacementId(ID);
+    assertThat("Unexpected other site count.", foundRecords.size(), is(0));
+
+    verify(repository).findOtherSitesByPlacementId(ID);
     verifyNoMoreInteractions(repository);
   }
 }


### PR DESCRIPTION
Persist PlacementSite changes to the sync DB, `LOAD`, `INSERT` and
`UPDATE` should perform an upsert and `DELETE` should remove the DB
record.

No caching is needed like other data types as there will never be direct
lookup by PlacementSite id.

TIS21-4986
TIS21-4396

---

Update placement enricher to populated a list of "Other Sites" based on
the PlacementSite data.
Request any sites that are completely missing, but otherwise follow the
existing site enrichment behaviour i.e. sync partial data so long as the
primary name exists.

TIS21-4967
TIS21-4968
TIS21-4396