### PR TITLE
feat: placement request/expansion for other sites

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.3.0"
+version = "1.4.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSiteSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
+
+/**
+ * A listener for Mongo events associated with PlacementSite data.
+ */
+@Slf4j
+@Component
+public class PlacementSiteEventListener extends AbstractMongoEventListener<PlacementSite> {
+
+  private final PlacementSiteSyncService placementSiteService;
+  private final PlacementSyncService placementService;
+  private final QueueMessagingTemplate messagingTemplate;
+  private final String placementQueueUrl;
+
+  private final Cache cache;
+
+  /**
+   * Construct a listener for PlacementSite Mongo events.
+   *
+   * @param placementSiteService The placement site service.
+   * @param placementService     The placement service.
+   * @param messagingTemplate    Queue messaging template for placement expansion.
+   * @param placementQueueUrl    The queue to expand placements in to.
+   * @param cacheManager         The cache for deleted records.
+   */
+  public PlacementSiteEventListener(PlacementSiteSyncService placementSiteService,
+      PlacementSyncService placementService, QueueMessagingTemplate messagingTemplate,
+      @Value("${application.aws.sqs.placement}") String placementQueueUrl,
+      CacheManager cacheManager) {
+    this.placementSiteService = placementSiteService;
+    this.placementService = placementService;
+    this.messagingTemplate = messagingTemplate;
+    this.placementQueueUrl = placementQueueUrl;
+    this.cache = cacheManager.getCache(PlacementSite.ENTITY_NAME);
+  }
+
+  /**
+   * After saving a placement site the related placements should be handled.
+   *
+   * @param event the after-save event for the placement site.
+   */
+  @Override
+  public void onAfterSave(AfterSaveEvent<PlacementSite> event) {
+    super.onAfterSave(event);
+
+    PlacementSite placementSite = event.getSource();
+    String placementId = placementSite.getPlacementId().toString();
+    Optional<Placement> optionalPlacement = placementService.findById(placementId);
+
+    if (optionalPlacement.isPresent()) {
+      log.debug("Placement {} found, queuing for re-sync.", placementId);
+
+      // Default the placement to LOAD.
+      Placement placement = optionalPlacement.get();
+      placement.setOperation(Operation.LOAD);
+      messagingTemplate.convertAndSend(placementQueueUrl, placement);
+    } else {
+      log.info("Placement {} not found, requesting data.", placementId);
+      placementService.request(placementId);
+    }
+  }
+
+  /**
+   * Before deleting a PlacementSite, ensure it is cached.
+   *
+   * @param event The before-delete event for the placement site.
+   */
+  @Override
+  public void onBeforeDelete(BeforeDeleteEvent<PlacementSite> event) {
+    super.onBeforeDelete(event);
+    Long id = event.getSource().getLong("_id");
+    PlacementSite placementSite = cache.get(id, PlacementSite.class);
+
+    if (placementSite == null) {
+      Optional<PlacementSite> newPlacement = placementSiteService.findById(id);
+      newPlacement.ifPresent(placementToCache -> cache.put(id, placementToCache));
+    }
+  }
+
+  /**
+   * Retrieve the deleted PlacementSite from the cache and sync the updated placement.
+   *
+   * @param event The after-delete event for the placement site.
+   */
+  @Override
+  public void onAfterDelete(AfterDeleteEvent<PlacementSite> event) {
+    super.onAfterDelete(event);
+    Long id = event.getSource().getLong("_id");
+    PlacementSite placementSite = cache.get(id, PlacementSite.class);
+
+    if (placementSite != null) {
+      String placementId = placementSite.getPlacementId().toString();
+      Optional<Placement> optionalPlacement = placementService.findById(placementId);
+
+      if (optionalPlacement.isPresent()) {
+        log.debug("Placement {} found, queuing for re-sync.", placementId);
+
+        // Default the placement to LOAD.
+        Placement placement = optionalPlacement.get();
+        placement.setOperation(Operation.LOAD);
+        messagingTemplate.convertAndSend(placementQueueUrl, placement);
+      }
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
@@ -22,29 +22,37 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.model.Site;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSiteSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
 
+@Slf4j
 @Component
 public class SiteEventListener extends AbstractMongoEventListener<Site> {
 
   private final PlacementSyncService placementService;
+  private final PlacementSiteSyncService placementSiteService;
 
   private final QueueMessagingTemplate messagingTemplate;
 
   private final String placementQueueUrl;
 
   SiteEventListener(PlacementSyncService placementService,
-      QueueMessagingTemplate messagingTemplate,
+      PlacementSiteSyncService placementSiteService, QueueMessagingTemplate messagingTemplate,
       @Value("${application.aws.sqs.placement}") String placementQueueUrl) {
     this.placementService = placementService;
+    this.placementSiteService = placementSiteService;
     this.messagingTemplate = messagingTemplate;
     this.placementQueueUrl = placementQueueUrl;
   }
@@ -53,10 +61,28 @@ public class SiteEventListener extends AbstractMongoEventListener<Site> {
   public void onAfterSave(AfterSaveEvent<Site> event) {
     super.onAfterSave(event);
 
-    Site site = event.getSource();
-    Set<Placement> placements = placementService.findBySiteId(site.getTisId());
+    String siteId = event.getSource().getTisId();
+    Set<PlacementSite> otherSites = placementSiteService.findOtherSitesBySiteId(
+        Long.parseLong(siteId));
+
+    Set<Placement> placements = new HashSet<>();
+
+    for (PlacementSite otherSite : otherSites) {
+      String placementId = otherSite.getPlacementId().toString();
+      Optional<Placement> placement = placementService.findById(placementId);
+
+      if (placement.isPresent()) {
+        placements.add(placement.get());
+      } else {
+        log.info("Placement {} not found, requesting data.", placementId);
+        placementService.request(placementId);
+      }
+    }
+
+    placements.addAll(placementService.findBySiteId(siteId));
 
     for (Placement placement : placements) {
+      log.debug("Placement {} found, queuing for re-sync.", placement.getTisId());
       // Default each placement to LOAD.
       placement.setOperation(Operation.LOAD);
       messagingTemplate.convertAndSend(placementQueueUrl, placement);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSiteRepository.java
@@ -31,6 +31,15 @@ import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 public interface PlacementSiteRepository extends MongoRepository<PlacementSite, Long> {
 
   /**
+   * Find PlacementSites with the OTHER type for the given site.
+   *
+   * @param siteId The site ID to filter by.
+   * @return The found PlacementSites, empty if no results.
+   */
+  @Query("{ $and: [ {'siteId' : ?0}, { 'placementSiteType' : \"OTHER\"} ] }")
+  Set<PlacementSite> findOtherSitesBySiteId(long siteId);
+
+  /**
    * Find PlacementSites with the OTHER type for the given placement.
    *
    * @param placementId The placement ID to filter by.

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.sync.service;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -58,6 +59,26 @@ public class PlacementSiteSyncService implements SyncService {
     } else {
       repository.save(placementSite);
     }
+  }
+
+  /**
+   * Find a PlacementSite by its ID.
+   *
+   * @param id The ID to search for.
+   * @return The PlacementSite if found, else empty.
+   */
+  public Optional<PlacementSite> findById(Long id) {
+    return repository.findById(id);
+  }
+
+  /**
+   * Find PlacementSites with the OTHER type for the given site.
+   *
+   * @param siteId The site ID to filter by.
+   * @return The found PlacementSites, empty if no results.
+   */
+  public Set<PlacementSite> findOtherSitesBySiteId(long siteId) {
+    return repository.findOtherSitesBySiteId(siteId);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListenerTest.java
@@ -1,0 +1,191 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import java.util.Optional;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.Placement;
+import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSiteSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
+
+class PlacementSiteEventListenerTest {
+
+  private static final String PLACEMENT_QUEUE_URL = "https://queue.placement";
+
+  private PlacementSiteEventListener listener;
+  private PlacementSyncService placementService;
+  private PlacementSiteSyncService placementSiteService;
+  private QueueMessagingTemplate messagingTemplate;
+  private Cache cache;
+
+  @BeforeEach
+  void setUp() {
+    placementSiteService = mock(PlacementSiteSyncService.class);
+    placementService = mock(PlacementSyncService.class);
+    messagingTemplate = mock(QueueMessagingTemplate.class);
+
+    CacheManager cacheManager = mock(CacheManager.class);
+    cache = mock(Cache.class);
+    when(cacheManager.getCache(anyString())).thenReturn(cache);
+
+    listener = new PlacementSiteEventListener(placementSiteService, placementService,
+        messagingTemplate, PLACEMENT_QUEUE_URL, cacheManager);
+  }
+
+  @Test
+  void shouldRequestPlacementWhenMissingAfterSave() {
+    PlacementSite placementSite = new PlacementSite();
+    placementSite.setId(1L);
+    placementSite.setPlacementId(2L);
+    AfterSaveEvent<PlacementSite> event = new AfterSaveEvent<>(placementSite, null, null);
+
+    when(placementService.findById("2")).thenReturn(Optional.empty());
+
+    listener.onAfterSave(event);
+
+    verify(placementService).request("2");
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldQueuePlacementWhenFoundAfterSave() {
+    PlacementSite placementSite = new PlacementSite();
+    placementSite.setId(1L);
+    placementSite.setPlacementId(2L);
+    AfterSaveEvent<PlacementSite> event = new AfterSaveEvent<>(placementSite, null, null);
+
+    Placement placement = new Placement();
+    placement.setTisId("2");
+    when(placementService.findById("2")).thenReturn(Optional.of(placement));
+
+    listener.onAfterSave(event);
+
+    verify(placementService, never()).request(any());
+    verify(messagingTemplate).convertAndSend(PLACEMENT_QUEUE_URL, placement);
+
+    assertThat("Unexpected operation.", placement.getOperation(), is(Operation.LOAD));
+  }
+
+  @Test
+  void shouldFindAndCachePlacementSiteIfNotInCacheBeforeDelete() {
+    PlacementSite placementSite = new PlacementSite();
+    placementSite.setId(1L);
+    when(cache.get(1L, PlacementSite.class)).thenReturn(null);
+    when(placementSiteService.findById(any())).thenReturn(Optional.of(placementSite));
+
+    Document document = new Document();
+    document.append("_id", 1L);
+    BeforeDeleteEvent<PlacementSite> event = new BeforeDeleteEvent<>(document, null, null);
+
+    listener.onBeforeDelete(event);
+
+    verify(placementSiteService).findById(1L);
+    verify(cache).put(1L, placementSite);
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldNotFindAndCachePlacementSiteIfInCacheBeforeDelete() {
+    Document document = new Document();
+    document.append("_id", 1L);
+    BeforeDeleteEvent<PlacementSite> event = new BeforeDeleteEvent<>(document, null, null);
+
+    PlacementSite placementSite = new PlacementSite();
+    when(cache.get(1L, PlacementSite.class)).thenReturn(placementSite);
+
+    listener.onBeforeDelete(event);
+
+    verifyNoInteractions(placementSiteService);
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldNotQueueRelatedPlacementWhenPlacementSiteNotInCacheAfterDelete() {
+    Document document = new Document();
+    document.append("_id", 1L);
+    AfterDeleteEvent<PlacementSite> event = new AfterDeleteEvent<>(document, null, null);
+
+    when(cache.get(1L, PlacementSite.class)).thenReturn(null);
+
+    listener.onAfterDelete(event);
+
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldNotQueueRelatedPlacementWhenPlacementNotFoundAfterDelete() {
+    PlacementSite placementSite = new PlacementSite();
+    placementSite.setPlacementId(2L);
+    when(cache.get(1L, PlacementSite.class)).thenReturn(placementSite);
+
+    when(placementService.findById("2")).thenReturn(Optional.empty());
+
+    Document document = new Document();
+    document.append("_id", 1L);
+    AfterDeleteEvent<PlacementSite> event = new AfterDeleteEvent<>(document, null, null);
+
+    listener.onAfterDelete(event);
+
+    verifyNoInteractions(messagingTemplate);
+  }
+
+  @Test
+  void shouldQueueRelatedPlacementWhenPlacementFoundAfterDelete() {
+    PlacementSite placementSite = new PlacementSite();
+    placementSite.setPlacementId(2L);
+    when(cache.get(1L, PlacementSite.class)).thenReturn(placementSite);
+
+    Placement placement = new Placement();
+    placement.setTisId("2");
+    when(placementService.findById("2")).thenReturn(Optional.of(placement));
+
+    Document document = new Document();
+    document.append("_id", 1L);
+    AfterDeleteEvent<PlacementSite> event = new AfterDeleteEvent<>(document, null, null);
+
+    listener.onAfterDelete(event);
+
+    verify(messagingTemplate).convertAndSend(PLACEMENT_QUEUE_URL, placement);
+
+    assertThat("Unexpected operation.", placement.getOperation(), is(Operation.LOAD));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSiteSyncServiceTest.java
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
-import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -112,10 +112,61 @@ class PlacementSiteSyncServiceTest {
   }
 
   @Test
+  void shouldFindOtherSiteByIdWhenExists() {
+    PlacementSite placementSite = new PlacementSite();
+    when(repository.findById(ID)).thenReturn(Optional.of(placementSite));
+
+    Optional<PlacementSite> optionalRecord = service.findById(ID);
+    assertThat("Unexpected placement site found.", optionalRecord.isPresent(), is(true));
+
+    PlacementSite foundRecord = optionalRecord.get();
+    assertThat("Unexpected other site.", foundRecord, sameInstance(placementSite));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindOtherSiteByIdWhenNotExists() {
+    when(repository.findById(ID)).thenReturn(Optional.empty());
+
+    Optional<PlacementSite> optionalRecord = service.findById(ID);
+    assertThat("Unexpected other site count.", optionalRecord.isPresent(), is(false));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindOtherSiteBySiteIdWhenExists() {
+    PlacementSite placementSite = new PlacementSite();
+    when(repository.findOtherSitesBySiteId(ID)).thenReturn(Set.of(placementSite));
+
+    Set<PlacementSite> foundRecords = service.findOtherSitesBySiteId(ID);
+    assertThat("Unexpected other site count.", foundRecords.size(), is(1));
+
+    PlacementSite foundRecord = foundRecords.iterator().next();
+    assertThat("Unexpected other site.", foundRecord, sameInstance(placementSite));
+
+    verify(repository).findOtherSitesBySiteId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindOtherSiteBySiteIdWhenNotExists() {
+    when(repository.findOtherSitesByPlacementId(ID)).thenReturn(Set.of());
+
+    Set<PlacementSite> foundRecords = service.findOtherSitesBySiteId(ID);
+    assertThat("Unexpected other site count.", foundRecords.size(), is(0));
+
+    verify(repository).findOtherSitesBySiteId(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
   void shouldFindOtherSiteByPlacementIdWhenExists() {
     PlacementSite placementSite = new PlacementSite();
-    when(repository.findOtherSitesByPlacementId(ID)).thenReturn(
-        Collections.singleton(placementSite));
+    when(repository.findOtherSitesByPlacementId(ID)).thenReturn(Set.of(placementSite));
 
     Set<PlacementSite> foundRecords = service.findOtherSitesByPlacementId(ID);
     assertThat("Unexpected other site count.", foundRecords.size(), is(1));
@@ -129,8 +180,7 @@ class PlacementSiteSyncServiceTest {
 
   @Test
   void shouldNotFindOtherSiteByPlacementIdWhenNotExists() {
-    when(repository.findOtherSitesByPlacementId(ID))
-        .thenReturn(Collections.emptySet());
+    when(repository.findOtherSitesByPlacementId(ID)).thenReturn(Set.of());
 
     Set<PlacementSite> foundRecords = service.findOtherSitesByPlacementId(ID);
     assertThat("Unexpected other site count.", foundRecords.size(), is(0));


### PR DESCRIPTION
Placements should be expanded in to the queue, or requested when missing based on PlacementSite relationships.

Create an event listener for placement sites which will expand placements found using the related placementId, or alternatively request the missing placement when not found. A deleted PlacementSite should also trigger a re-sync of the Placement by re-queuing it to be synced.

Update the site event listener to also handle the placements related to "other sites", using the PlacementSite records as a joining record.

TIS21-4969
TIS21-4396