### PR TITLE
fix: WTE field naming variations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.7.0"
+version = "1.7.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.ConditionsOfJoining;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.Curricula;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.OtherSites;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.WholeTimeEquivalent;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 
 @Mapper(componentModel = "spring", uses = TraineeDetailsUtil.class,
@@ -101,7 +102,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "specialty", source = "data.specialty")
   @Mapping(target = "subSpecialty", source = "data.subSpecialty")
   @Mapping(target = "postAllowsSubspecialty", source = "data.postAllowsSubspecialty")
-  @Mapping(target = "wholeTimeEquivalent", source = "data.placementWholeTimeEquivalent")
+  @Mapping(target = "wholeTimeEquivalent", source = "data", qualifiedBy = WholeTimeEquivalent.class)
   TraineeDetailsDto toPlacementDto(Record recrd);
 
   @Mapping(target = "traineeTisId", source = "data.personId")

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
@@ -61,6 +61,13 @@ public class TraineeDetailsUtil {
 
   }
 
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface WholeTimeEquivalent {
+
+  }
+
   /**
    * Gets the set of curricula from the data map String.
    *
@@ -129,5 +136,17 @@ public class TraineeDetailsUtil {
     }
 
     return otherSites;
+  }
+
+  /**
+   * Gets the whole time equivalent from one of two possible field names.
+   *
+   * @param data the data containing the whole time equivalent.
+   * @return The whole time equivalent value.
+   */
+  @WholeTimeEquivalent
+  public String wholeTimeEquivalent(Map<String, String> data) {
+    // TODO: remove once requested Placement data from TCS is standardised.
+    return data.getOrDefault("placementWholeTimeEquivalent", data.get("wholeTimeEquivalent"));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
@@ -22,13 +22,16 @@
 package uk.nhs.hee.tis.trainee.sync.mapper;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.ReflectionUtils;
 import uk.nhs.hee.tis.trainee.sync.dto.TraineeDetailsDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil;
@@ -50,7 +53,7 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapCurriculaToEmptySetWhenBadJson() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("curricula", "bad JSON"));
+    recrd.setData(Map.of("curricula", "bad JSON"));
 
     TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
@@ -60,7 +63,7 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapCurriculaToEmptySetWhenMissing() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("curricula", null));
+    recrd.setData(Map.of());
 
     TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
@@ -70,7 +73,7 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapConditionsOfJoiningToEmptyMapWhenBadJson() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("conditionsOfJoining", "bad JSON"));
+    recrd.setData(Map.of("conditionsOfJoining", "bad JSON"));
 
     TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
@@ -81,7 +84,7 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapConditionsOfJoiningToEmptyMapWhenMissing() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("conditionsOfJoining", null));
+    recrd.setData(Map.of());
 
     TraineeDetailsDto traineeDetails = mapper.toProgrammeMembershipDto(recrd);
 
@@ -92,7 +95,7 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapOtherSitesToEmptySetWhenBadJson() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("otherSites", "bad JSON"));
+    recrd.setData(Map.of("otherSites", "bad JSON"));
 
     TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
 
@@ -102,10 +105,31 @@ class TraineeDetailsMapperTest {
   @Test
   void shouldMapOtherSitesToEmptySetWhenMissing() {
     Record recrd = new Record();
-    recrd.setData(Collections.singletonMap("otherSites", null));
+    recrd.setData(Map.of());
 
     TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
 
     assertThat("Unexpected curricula size.", traineeDetails.getOtherSites().size(), is(0));
+  }
+
+  @Test
+  void shouldMapWholeTimeEquivalentToNullWhenMissing() {
+    Record recrd = new Record();
+    recrd.setData(Map.of());
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected WTE.", traineeDetails.getWholeTimeEquivalent(), nullValue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"wholeTimeEquivalent", "placementWholeTimeEquivalent"})
+  void shouldMapWholeTimeEquivalentForDifferentFieldNames(String fieldName) {
+    Record recrd = new Record();
+    recrd.setData(Map.of(fieldName, "0.5"));
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected WTE.", traineeDetails.getWholeTimeEquivalent(), is("0.5"));
   }
 }


### PR DESCRIPTION
The WTE field naming differs based on how it was received. If received via DMS it has the database naming of
`placementWholeTimeEquivalent`. However, if it is sent as a result of a re-sync request it is named `wholeTimeEquivalent`.

Update the TraineeDetailsMapper to handle both names for this field.

TIS21-5140