### PR TITLE
fix: use new FIFO SNS for PM updates

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -114,7 +114,7 @@
         },
         {
           "name": "UPDATE_PROGRAMME_MEMBERSHIP_TOPIC_ARN",
-          "valueFrom": "/tis/trainee/sync/${environment}/topic-arn/update-programme-membership-event"
+          "valueFrom": "/tis/trainee/sync/${environment}/topic-arn/update-programme-membership-event-fifo"
         },
         {
           "name": "REDIS_HOST",

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.8.0"
+version = "1.8.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
Dependent on https://github.com/Health-Education-England/TIS-OPS/pull/680

TIS21-5057