### PR TITLE
fix: send unwrapped PmEventDto for CoJ SNS broadcast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.8.2"
+version = "1.8.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateCurriculumMembershipDto;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateProgrammeMembershipDto;
+import uk.nhs.hee.tis.trainee.sync.dto.ProgrammeMembershipEventDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.AggregateMapper;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipEventMapper;
 import uk.nhs.hee.tis.trainee.sync.model.ConditionsOfJoining;
@@ -110,10 +111,9 @@ public class ProgrammeMembershipEnricherFacade {
         = buildAggregateProgrammeMembershipDto(programmeMembership);
 
     if (aggregatePmDto != null) {
-      Record programmeMembershipEventRecord = eventMapper.toRecord(aggregatePmDto);
-      programmeMembershipEventRecord.setOperation(LOAD);
-      programmeMembershipEventRecord.setTable(ConditionsOfJoining.ENTITY_NAME);
-      tcsSyncService.publishDetailsChangeEvent(programmeMembershipEventRecord);
+      ProgrammeMembershipEventDto pmEventDto
+          = eventMapper.toProgrammeMembershipEventDto(aggregatePmDto);
+      tcsSyncService.publishDetailsChangeEvent(pmEventDto);
     } else {
       log.warn("Aggregate programme membership (uuid '{}') could not be built, so CoJ "
               + "signing event could not be broadcast. This may reflect a data issue: all"

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -47,6 +47,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.nhs.hee.tis.trainee.sync.dto.ProgrammeMembershipEventDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.AggregateMapper;
 import uk.nhs.hee.tis.trainee.sync.mapper.AggregateMapperImpl;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipEventMapper;
@@ -359,6 +360,6 @@ class ProgrammeMembershipEnricherFacadeTest {
 
     enricher.broadcastCoj(programmeMembership);
 
-    verify(tcsSyncService).publishDetailsChangeEvent(any());
+    verify(tcsSyncService).publishDetailsChangeEvent(any(ProgrammeMembershipEventDto.class));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -52,7 +52,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.Comparator;
@@ -81,7 +80,6 @@ import org.springframework.web.client.RestTemplate;
 import uk.nhs.hee.tis.trainee.sync.config.EventNotificationProperties;
 import uk.nhs.hee.tis.trainee.sync.config.EventNotificationProperties.SnsRoute;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateProgrammeMembershipDto;
-import uk.nhs.hee.tis.trainee.sync.dto.ConditionsOfJoiningDto;
 import uk.nhs.hee.tis.trainee.sync.dto.ProgrammeMembershipEventDto;
 import uk.nhs.hee.tis.trainee.sync.dto.TraineeDetailsDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.TraineeDetailsMapper;
@@ -893,11 +891,6 @@ class TcsSyncServiceTest {
     ProgrammeMembershipEventDto programmeMembershipEventDto = new ProgrammeMembershipEventDto();
     AggregateProgrammeMembershipDto aggregatePmDto = new AggregateProgrammeMembershipDto();
     aggregatePmDto.setTisId("idValue");
-    aggregatePmDto.setPersonId("personId");
-    aggregatePmDto.setManagingDeanery("managingDeanery");
-    ConditionsOfJoiningDto conditionsOfJoiningDto = new ConditionsOfJoiningDto();
-
-    aggregatePmDto.setConditionsOfJoining(conditionsOfJoiningDto);
     programmeMembershipEventDto.setProgrammeMembership(aggregatePmDto);
 
     service.publishDetailsChangeEvent(programmeMembershipEventDto);


### PR DESCRIPTION
A wrapped Record object was being sent, which the notification service was not expecting. This was consistent with the data structures sent to tis-trainee-details and tis-trainee-credentials, but longer term the intention is to refactor these as well.

NO-TICKET