### PR TITLE
fix: include curriculum specialtycode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.9.0"
+version = "1.9.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateCurriculumMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateCurriculumMembershipDto.java
@@ -34,6 +34,7 @@ public class AggregateCurriculumMembershipDto {
   private String curriculumName;
   private String curriculumSubType;
   private String curriculumSpecialty;
+  private String curriculumSpecialtyCode;
   private String curriculumMembershipId;
   private LocalDate curriculumStartDate;
   private LocalDate curriculumEndDate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -63,6 +63,7 @@ public interface AggregateMapper {
   @Mapping(target = "curriculumName", source = "curriculum.data.name")
   @Mapping(target = "curriculumSubType", source = "curriculum.data.curriculumSubType")
   @Mapping(target = "curriculumSpecialty", source = "specialty.data.name")
+  @Mapping(target = "curriculumSpecialtyCode", source = "specialty.data.specialtyCode")
   @Mapping(target = "curriculumMembershipId", source = "curriculumMembership.tisId")
   @Mapping(target = "curriculumStartDate", source = "curriculumMembership.data.curriculumStartDate")
   @Mapping(target = "curriculumEndDate", source = "curriculumMembership.data.curriculumEndDate")

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -118,6 +118,8 @@ class ProgrammeMembershipEnricherFacadeTest {
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_NAME = "curriculumName";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY
       = "curriculumSpecialty";
+  private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY_CODE
+      = "curriculumSpecialtyCode";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_START_DATE
       = "curriculumStartDate";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_END_DATE

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
@@ -83,6 +83,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
 
   private static final String SPECIALTY_ID = "154";
   private static final String SPECIALTY_NAME = "Medical Microbiology";
+  private static final String SPECIALTY_CODE = "X75";
 
   private static final String CURRICULUM_MEMBERSHIP_ID = UUID.randomUUID().toString();
   private static final LocalDate CURRICULUM_MEMBERSHIP_START_DATE = LocalDate.now().minusYears(1L);
@@ -159,7 +160,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
     specialty.setTisId(SPECIALTY_ID);
     specialty.setData(Map.of(
         "id", SPECIALTY_ID,
-        "name", SPECIALTY_NAME
+        "name", SPECIALTY_NAME,
+        "specialtyCode", SPECIALTY_CODE
     ));
     specialtyRepository.save(specialty);
 
@@ -303,7 +305,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
     assertThat("Unexpected curricula count.", curricula.size(), is(1));
 
     Map<String, String> curriculum = curricula.iterator().next();
-    assertThat("Unexpected curricula field count.", curriculum.size(), is(7));
+    assertThat("Unexpected curricula field count.", curriculum.size(), is(8));
     assertThat("Unexpected curriculum TIS ID.", curriculum.get("curriculumTisId"),
         is(CURRICULUM_ID));
     assertThat("Unexpected curriculum name.", curriculum.get("curriculumName"),
@@ -312,6 +314,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(CURRICULUM_SUB_TYPE));
     assertThat("Unexpected curriculum specialty.", curriculum.get("curriculumSpecialty"),
         is(SPECIALTY_NAME));
+    assertThat("Unexpected curriculum specialty code.",
+        curriculum.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
     assertThat("Unexpected curriculum membership ID.", curriculum.get("curriculumMembershipId"),
         is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", curriculum.get("curriculumStartDate"),
@@ -381,7 +385,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         .sorted(Comparator.comparing(c -> c.get("curriculumStartDate"))).toList();
 
     Map<String, String> curriculum1 = sortedCurricula.get(0);
-    assertThat("Unexpected curricula field count.", curriculum1.size(), is(7));
+    assertThat("Unexpected curricula field count.", curriculum1.size(), is(8));
     assertThat("Unexpected curriculum TIS ID.", curriculum1.get("curriculumTisId"),
         is(CURRICULUM_ID));
     assertThat("Unexpected curriculum name.", curriculum1.get("curriculumName"),
@@ -390,6 +394,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(CURRICULUM_SUB_TYPE));
     assertThat("Unexpected curriculum specialty.", curriculum1.get("curriculumSpecialty"),
         is(SPECIALTY_NAME));
+    assertThat("Unexpected curriculum specialty code.",
+        curriculum1.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
     assertThat("Unexpected curriculum membership ID.", curriculum1.get("curriculumMembershipId"),
         is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", curriculum1.get("curriculumStartDate"),
@@ -407,6 +413,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(CURRICULUM_SUB_TYPE));
     assertThat("Unexpected curriculum specialty.", curriculum2.get("curriculumSpecialty"),
         is(SPECIALTY_NAME));
+    assertThat("Unexpected curriculum specialty code.",
+        curriculum2.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
     assertThat("Unexpected curriculum membership ID.", curriculum2.get("curriculumMembershipId"),
         is(curriculumMembershipId));
     assertThat("Unexpected curriculum start date.", curriculum2.get("curriculumStartDate"),

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
@@ -404,7 +404,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(CURRICULUM_MEMBERSHIP_END_DATE.toString()));
 
     Map<String, String> curriculum2 = sortedCurricula.get(1);
-    assertThat("Unexpected curricula field count.", curriculum2.size(), is(7));
+    assertThat("Unexpected curricula field count.", curriculum2.size(), is(8));
     assertThat("Unexpected curriculum TIS ID.", curriculum2.get("curriculumTisId"),
         is(curriculumId));
     assertThat("Unexpected curriculum name.", curriculum2.get("curriculumName"),

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
@@ -57,6 +57,7 @@ class AggregateMapperTest {
   private static final String CURRICULUM_SUB_TYPE = "MEDICAL_CURRICULUM";
 
   private static final String SPECIALTY_NAME = "Medical Microbiology";
+  private static final String SPECIALTY_CODE = "X75";
 
   private static final String CURRICULUM_MEMBERSHIP_ID = UUID.randomUUID().toString();
   private static final LocalDate CURRICULUM_MEMBERSHIP_START_DATE = LocalDate.now().minusYears(1L);
@@ -94,7 +95,8 @@ class AggregateMapperTest {
 
     Specialty specialty = new Specialty();
     specialty.setData(Map.of(
-        "name", SPECIALTY_NAME)
+        "name", SPECIALTY_NAME,
+        "specialtyCode", SPECIALTY_CODE)
     );
 
     CurriculumMembership curriculumMembership = new CurriculumMembership();
@@ -115,6 +117,8 @@ class AggregateMapperTest {
         is(CURRICULUM_SUB_TYPE));
     assertThat("Unexpected curriculum specialty.",
         aggregateCurriculum.getCurriculumSpecialty(), is(SPECIALTY_NAME));
+    assertThat("Unexpected curriculum specialty code.",
+        aggregateCurriculum.getCurriculumSpecialtyCode(), is(SPECIALTY_CODE));
     assertThat("Unexpected curriculum membership ID.",
         aggregateCurriculum.getCurriculumMembershipId(), is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", aggregateCurriculum.getCurriculumStartDate(),


### PR DESCRIPTION
This is needed to identify specialties that have different names but should be considered the same for the purposes of calculating whether a programme is a new starter or not.

TIS21-5720