### PR TITLE
feat: include block indemnity in PM enrichment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.10.2"
+version = "1.11.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateCurriculumMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateCurriculumMembershipDto.java
@@ -35,6 +35,7 @@ public class AggregateCurriculumMembershipDto {
   private String curriculumSubType;
   private String curriculumSpecialty;
   private String curriculumSpecialtyCode;
+  private boolean curriculumSpecialtyBlockIndemnity;
   private String curriculumMembershipId;
   private LocalDate curriculumStartDate;
   private LocalDate curriculumEndDate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -234,12 +234,10 @@ public class PlacementEnricherFacade {
       if (placementSpecialtyType.equals(PLACEMENT_SPECIALTY_TYPE_PRIMARY)) {
         populateSpecialtyDetails(placement, specialtyName);
         return true;
-      }
-      else if (placementSpecialtyType.equals(PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY)) {
+      } else if (placementSpecialtyType.equals(PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY)) {
         populateSubSpecialtyDetails(placement, specialtyName);
         return true;
-      }
-      else {
+      } else {
         return false;
       }
     }
@@ -361,11 +359,10 @@ public class PlacementEnricherFacade {
       Optional<Specialty> optionalPrimarySpecialty =
           getSpecialty(getSpecialtyId(primaryPlacementSpecialty));
 
-      isEnriched = optionalPrimarySpecialty.
-          filter(specialty ->
+      isEnriched = optionalPrimarySpecialty
+          .filter(specialty ->
               enrich(placement, specialty, PLACEMENT_SPECIALTY_TYPE_PRIMARY)).isPresent();
-    }
-    else {
+    } else {
       placementSpecialtyService.request(placementId);
       // isEnriched is not affected by a missing placement specialty
     }
@@ -378,8 +375,8 @@ public class PlacementEnricherFacade {
       Optional<Specialty> optionalSubSpecialty =
           getSpecialty(getSpecialtyId(subPlacementSpecialty));
 
-      isEnriched = optionalSubSpecialty.
-          filter(specialty ->
+      isEnriched = optionalSubSpecialty
+          .filter(specialty ->
               enrich(placement, specialty, PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY)).isPresent();
     }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -64,6 +64,7 @@ public interface AggregateMapper {
   @Mapping(target = "curriculumSubType", source = "curriculum.data.curriculumSubType")
   @Mapping(target = "curriculumSpecialty", source = "specialty.data.name")
   @Mapping(target = "curriculumSpecialtyCode", source = "specialty.data.specialtyCode")
+  @Mapping(target = "curriculumSpecialtyBlockIndemnity", source = "specialty.data.blockIndemnity")
   @Mapping(target = "curriculumMembershipId", source = "curriculumMembership.tisId")
   @Mapping(target = "curriculumStartDate", source = "curriculumMembership.data.curriculumStartDate")
   @Mapping(target = "curriculumEndDate", source = "curriculumMembership.data.curriculumEndDate")
@@ -132,6 +133,16 @@ public interface AggregateMapper {
     programmeMembershipRecord.setData(recordData);
     programmeMembershipRecord.setTisId(aggregateProgrammeMembershipDto.getTisId());
     return programmeMembershipRecord;
+  }
+
+  /**
+   * Parse a boolean from a string value.
+   *
+   * @param s The string to parse.
+   * @return The parsed boolean.
+   */
+  default boolean parseBoolean(String s) {
+    return Boolean.parseBoolean(s) || Objects.equals("1", s);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -103,8 +103,12 @@ class ProgrammeMembershipEnricherFacadeTest {
   private static final String DATA_CURRICULUM_END_DATE = "curriculumEndDate";
 
   private static final String SPECIALTY_NAME = "name";
+  private static final String SPECIALTY_CODE = "specialtyCode";
+  private static final String SPECIALTY_BLOCK_INDEMNITY = "blockIndemnity";
   private static final String SPECIALTY_1_ID = "154";
   private static final String SPECIALTY_1_NAME = "Medical Microbiology";
+  private static final String SPECIALTY_1_CODE = "ABC123";
+  private static final String SPECIALTY_1_BLOCK_INDEMNITY = "true";
 
   // processed fields in programmeMembership DTO passed to trainee-details for persisting
   private static final String PROGRAMME_MEMBERSHIP_DATA_PROGRAMME_NAME = "programmeName";
@@ -120,6 +124,8 @@ class ProgrammeMembershipEnricherFacadeTest {
       = "curriculumSpecialty";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY_CODE
       = "curriculumSpecialtyCode";
+  private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY_BLOCK_INDEMNITY
+      = "curriculumSpecialtyBlockIndemnity";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_START_DATE
       = "curriculumStartDate";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_END_DATE
@@ -192,7 +198,9 @@ class ProgrammeMembershipEnricherFacadeTest {
 
     Specialty specialty = new Specialty();
     specialty.setData(Map.of(
-        SPECIALTY_NAME, SPECIALTY_1_NAME
+        SPECIALTY_NAME, SPECIALTY_1_NAME,
+        SPECIALTY_CODE, SPECIALTY_1_CODE,
+        SPECIALTY_BLOCK_INDEMNITY, SPECIALTY_1_BLOCK_INDEMNITY
     ));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty));
 
@@ -244,6 +252,12 @@ class ProgrammeMembershipEnricherFacadeTest {
     assertThat("Unexpected curriculum specialty.",
         curriculumData.get(PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY),
         is(SPECIALTY_1_NAME));
+    assertThat("Unexpected curriculum specialty code.",
+        curriculumData.get(PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY_CODE),
+        is(SPECIALTY_1_CODE));
+    assertThat("Unexpected curriculum specialty block indemnity.",
+        curriculumData.get(PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_SPECIALTY_BLOCK_INDEMNITY),
+        is(SPECIALTY_1_BLOCK_INDEMNITY));
     assertThat("Unexpected curriculum start date.",
         curriculumData.get(PROGRAMME_MEMBERSHIP_DATA_CURRICULUM_START_DATE),
         is(CURRICULUM_1_START_DATE.toString()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnrichmentIntegrationTest.java
@@ -84,6 +84,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
   private static final String SPECIALTY_ID = "154";
   private static final String SPECIALTY_NAME = "Medical Microbiology";
   private static final String SPECIALTY_CODE = "X75";
+  private static final String SPECIALTY_BLOCK_INDEMNITY = "0";
 
   private static final String CURRICULUM_MEMBERSHIP_ID = UUID.randomUUID().toString();
   private static final LocalDate CURRICULUM_MEMBERSHIP_START_DATE = LocalDate.now().minusYears(1L);
@@ -161,7 +162,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
     specialty.setData(Map.of(
         "id", SPECIALTY_ID,
         "name", SPECIALTY_NAME,
-        "specialtyCode", SPECIALTY_CODE
+        "specialtyCode", SPECIALTY_CODE,
+        "blockIndemnity", SPECIALTY_BLOCK_INDEMNITY
     ));
     specialtyRepository.save(specialty);
 
@@ -305,7 +307,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
     assertThat("Unexpected curricula count.", curricula.size(), is(1));
 
     Map<String, String> curriculum = curricula.iterator().next();
-    assertThat("Unexpected curricula field count.", curriculum.size(), is(8));
+    assertThat("Unexpected curricula field count.", curriculum.size(), is(9));
     assertThat("Unexpected curriculum TIS ID.", curriculum.get("curriculumTisId"),
         is(CURRICULUM_ID));
     assertThat("Unexpected curriculum name.", curriculum.get("curriculumName"),
@@ -316,6 +318,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(SPECIALTY_NAME));
     assertThat("Unexpected curriculum specialty code.",
         curriculum.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
+    assertThat("Unexpected curriculum specialty block indemnity.",
+        curriculum.get("curriculumSpecialtyBlockIndemnity"), is("false"));
     assertThat("Unexpected curriculum membership ID.", curriculum.get("curriculumMembershipId"),
         is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", curriculum.get("curriculumStartDate"),
@@ -326,6 +330,17 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
 
   @Test
   void shouldEnrichProgrammeMembershipWithMultipleCurriculaWhenTriggeredByProgrammeMembership() {
+    Specialty specialty = new Specialty();
+    String specialtyId = UUID.randomUUID().toString();
+    specialty.setTisId(specialtyId);
+    specialty.setData(Map.of(
+        "id", specialtyId,
+        "name", "Another specialty",
+        "specialtyCode", "ABC123",
+        "blockIndemnity", "1"
+    ));
+    specialtyRepository.save(specialty);
+
     Curriculum curriculum = new Curriculum();
     String curriculumId = UUID.randomUUID().toString();
     curriculum.setTisId(curriculumId);
@@ -333,7 +348,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         "id", curriculumId,
         "name", "Additional Curriculum",
         "curriculumSubType", CURRICULUM_SUB_TYPE,
-        "specialtyId", SPECIALTY_ID
+        "specialtyId", specialtyId,
+        "curriculumSpecialtyBlockIndemnity", "1"
     ));
     curriculumRepository.save(curriculum);
 
@@ -385,7 +401,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         .sorted(Comparator.comparing(c -> c.get("curriculumStartDate"))).toList();
 
     Map<String, String> curriculum1 = sortedCurricula.get(0);
-    assertThat("Unexpected curricula field count.", curriculum1.size(), is(8));
+    assertThat("Unexpected curricula field count.", curriculum1.size(), is(9));
     assertThat("Unexpected curriculum TIS ID.", curriculum1.get("curriculumTisId"),
         is(CURRICULUM_ID));
     assertThat("Unexpected curriculum name.", curriculum1.get("curriculumName"),
@@ -396,6 +412,8 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(SPECIALTY_NAME));
     assertThat("Unexpected curriculum specialty code.",
         curriculum1.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
+    assertThat("Unexpected curriculum specialty block indemnity.",
+        curriculum1.get("curriculumSpecialtyBlockIndemnity"), is("false"));
     assertThat("Unexpected curriculum membership ID.", curriculum1.get("curriculumMembershipId"),
         is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", curriculum1.get("curriculumStartDate"),
@@ -404,7 +422,7 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
         is(CURRICULUM_MEMBERSHIP_END_DATE.toString()));
 
     Map<String, String> curriculum2 = sortedCurricula.get(1);
-    assertThat("Unexpected curricula field count.", curriculum2.size(), is(8));
+    assertThat("Unexpected curricula field count.", curriculum2.size(), is(9));
     assertThat("Unexpected curriculum TIS ID.", curriculum2.get("curriculumTisId"),
         is(curriculumId));
     assertThat("Unexpected curriculum name.", curriculum2.get("curriculumName"),
@@ -412,9 +430,11 @@ class ProgrammeMembershipEnrichmentIntegrationTest {
     assertThat("Unexpected curriculum sub-type.", curriculum2.get("curriculumSubType"),
         is(CURRICULUM_SUB_TYPE));
     assertThat("Unexpected curriculum specialty.", curriculum2.get("curriculumSpecialty"),
-        is(SPECIALTY_NAME));
+        is("Another specialty"));
     assertThat("Unexpected curriculum specialty code.",
-        curriculum2.get("curriculumSpecialtyCode"), is(SPECIALTY_CODE));
+        curriculum2.get("curriculumSpecialtyCode"), is("ABC123"));
+    assertThat("Unexpected curriculum specialty block indemnity.",
+        curriculum2.get("curriculumSpecialtyBlockIndemnity"), is("true"));
     assertThat("Unexpected curriculum membership ID.", curriculum2.get("curriculumMembershipId"),
         is(curriculumMembershipId));
     assertThat("Unexpected curriculum start date.", curriculum2.get("curriculumStartDate"),

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
@@ -37,6 +37,9 @@ import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateCurriculumMembershipDto;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.sync.dto.ConditionsOfJoiningDto;
@@ -96,7 +99,8 @@ class AggregateMapperTest {
     Specialty specialty = new Specialty();
     specialty.setData(Map.of(
         "name", SPECIALTY_NAME,
-        "specialtyCode", SPECIALTY_CODE)
+        "specialtyCode", SPECIALTY_CODE,
+        "blockIndemnity", "1")
     );
 
     CurriculumMembership curriculumMembership = new CurriculumMembership();
@@ -119,6 +123,8 @@ class AggregateMapperTest {
         aggregateCurriculum.getCurriculumSpecialty(), is(SPECIALTY_NAME));
     assertThat("Unexpected curriculum specialty code.",
         aggregateCurriculum.getCurriculumSpecialtyCode(), is(SPECIALTY_CODE));
+    assertThat("Unexpected curriculum specialty block indemnity.",
+        aggregateCurriculum.isCurriculumSpecialtyBlockIndemnity(), is(true));
     assertThat("Unexpected curriculum membership ID.",
         aggregateCurriculum.getCurriculumMembershipId(), is(CURRICULUM_MEMBERSHIP_ID));
     assertThat("Unexpected curriculum start date.", aggregateCurriculum.getCurriculumStartDate(),
@@ -368,5 +374,20 @@ class AggregateMapperTest {
         is(List.of(curriculumMembership)));
     assertThat("Unexpected Conditions of joining", programmeMembership.getConditionsOfJoining(),
         is(conditionsOfJoiningDto));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"1", "true"})
+  void shouldParseBooleanWhenStringIsTruthy(String strBool) {
+    boolean bool = mapper.parseBoolean(strBool);
+    assertThat("Unexpected parsed boolean.", bool, is(true));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {"0", "false", "lorem ipsum"})
+  void shouldParseBooleanWhenStringIsNotTruthy(String strBool) {
+    boolean bool = mapper.parseBoolean(strBool);
+    assertThat("Unexpected parsed boolean.", bool, is(false));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
@@ -201,8 +201,8 @@ class PlacementSpecialtySyncServiceTest {
         PLACEMENT_SPECIALTY_PLACEMENT_ID, PLACEMENT_ID_1)));
 
     when(repository.findByPlacementIdAndSpecialtyType(
-        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY)).
-        thenReturn(existingPlacementSpecialty);
+        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY))
+        .thenReturn(existingPlacementSpecialty);
 
     service.syncPlacementSpecialty(placementSpecialty);
 
@@ -228,8 +228,8 @@ class PlacementSpecialtySyncServiceTest {
     newPlacementSpecialty.setData(data);
 
     when(repository.findByPlacementIdAndSpecialtyType(
-        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY)).
-        thenReturn(newPlacementSpecialty);
+        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY))
+        .thenReturn(newPlacementSpecialty);
     service.syncPlacementSpecialty(placementSpecialty);
 
     verify(repository).findByPlacementIdAndSpecialtyType(
@@ -250,8 +250,8 @@ class PlacementSpecialtySyncServiceTest {
 
     // newRecord(LOAD) being already present before record(DELETE) is synced
     when(repository.findByPlacementIdAndSpecialtyType(
-        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY)).
-        thenReturn(newPlacementSpecialty);
+        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY))
+        .thenReturn(newPlacementSpecialty);
     service.syncPlacementSpecialty(placementSpecialty);
 
     verify(repository).findByPlacementIdAndSpecialtyType(
@@ -271,8 +271,8 @@ class PlacementSpecialtySyncServiceTest {
     newPlacementSpecialty.setData(data);
 
     when(repository.findByPlacementIdAndSpecialtyType(
-        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY)).
-        thenReturn(null);
+        PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY))
+        .thenReturn(null);
     service.syncPlacementSpecialty(placementSpecialty);
 
     verify(repository).findByPlacementIdAndSpecialtyType(


### PR DESCRIPTION
The specialty associated with a Programme Membership includes a `blockIndemnity` flag. This flag should be included in the PM data when it is enriched.

Update the AggregateCurriculumMembershDto and associated mapping functions to handle the `blockIndemnity` field. It is a `tinybit` so the raw data in the record will be `1` or `0` when present, and will need converting to a boolean.

TIS21-5617
TIS21-5849