### PR TITLE
feat: include placement other specialties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.11.0"
+version = "1.12.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -83,6 +83,7 @@ public class TraineeDetailsDto {
   private String specialty;
   private String subSpecialty;
   private Boolean postAllowsSubspecialty;
+  private String otherSpecialties; //denormalized: alphabetic order, comma-delimited
   private String placementType;
   private String wholeTimeEquivalent;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -83,7 +83,7 @@ public class TraineeDetailsDto {
   private String specialty;
   private String subSpecialty;
   private Boolean postAllowsSubspecialty;
-  private String otherSpecialties; //denormalized: alphabetic order, comma-delimited
+  private Set<Map<String, String>> otherSpecialties;
   private String placementType;
   private String wholeTimeEquivalent;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
@@ -85,7 +85,7 @@ public class SpecialtyEventListener extends AbstractMongoEventListener<Specialty
    */
   private void sendPlacementSpecialtyMessages(String specialtyId, Operation operation) {
     Set<PlacementSpecialty> placementSpecialties = placementSpecialtyService
-        .findPlacementSpecialtiesBySpecialtyId(specialtyId);
+        .findBySpecialtyId(specialtyId);
 
     for (PlacementSpecialty placementSpecialty : placementSpecialties) {
       // Default each placement specialty's operation.

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
@@ -85,7 +85,7 @@ public class SpecialtyEventListener extends AbstractMongoEventListener<Specialty
    */
   private void sendPlacementSpecialtyMessages(String specialtyId, Operation operation) {
     Set<PlacementSpecialty> placementSpecialties = placementSpecialtyService
-        .findPrimaryAndSubPlacementSpecialtiesBySpecialtyId(specialtyId);
+        .findPlacementSpecialtiesBySpecialtyId(specialtyId);
 
     for (PlacementSpecialty placementSpecialty : placementSpecialties) {
       // Default each placement specialty's operation.

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -246,8 +246,6 @@ public class PlacementEnricherFacade {
       } else if (placementSpecialtyType.equals(PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY)) {
         populateSubSpecialtyDetails(placement, specialtyName);
         return true;
-      } else {
-        return false;
       }
     }
 
@@ -485,7 +483,7 @@ public class PlacementEnricherFacade {
     Set<Specialty> otherSpecialties = new HashSet<>();
     otherPlacementSpecialties.forEach(ps -> {
       String specialtyId = ps.getData().get(PLACEMENT_SPECIALTY_SPECIALTY_ID);
-      Optional<Specialty> optionalSpecialty = specialtyService.findById(specialtyId);
+      Optional<Specialty> optionalSpecialty = getSpecialty(specialtyId);
       optionalSpecialty.ifPresent(otherSpecialties::add);
     });
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -26,7 +26,6 @@ import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOAD;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -79,17 +78,19 @@ public class PlacementEnricherFacade {
   private static final String PLACEMENT_DATA_SPECIALTY_NAME = "specialty";
   private static final String PLACEMENT_DATA_SUB_SPECIALTY_NAME = "subSpecialty";
   private static final String PLACEMENT_DATA_OTHER_SPECIALTIES_NAME = "otherSpecialties";
-  private static final String PLACEMENT_SPECIALTY_SPECIALITY_ID = "specialtyId";
+  private static final String PLACEMENT_DATA_OTHER_SPECIALTIES_SPECIALTY_NAME = "name";
+  private static final String PLACEMENT_DATA_OTHER_SPECIALTIES_ID_NAME = "specialtyId";
   private static final String PLACEMENT_OWNER = "owner";
   private static final String SITE_NAME = "siteName";
   private static final String SITE_LOCATION = "address";
   private static final String SITE_KNOWN_AS = "siteKnownAs";
   private static final String GRADE_ABBREVIATION = "abbreviation";
+  private static final String SPECIALTY_ID = "id";
   private static final String SPECIALTY_NAME = "name";
   private static final String PLACEMENT_SPECIALTY_TYPE_PRIMARY = "PRIMARY";
   private static final String PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY = "SUB_SPECIALTY";
   private static final String PLACEMENT_SPECIALTY_TYPE_OTHER = "OTHER";
-  private static final String PLACEMENT_SPECIALTY_SPECIALTY_ID = "specialtyId";
+  private static final String PLACEMENT_SPECIALTY_SPECIALTY_ID_NAME = "specialtyId";
 
   private final PostSyncService postService;
   private final PostSpecialtySyncService postSpecialtyService;
@@ -148,6 +149,7 @@ public class PlacementEnricherFacade {
     doSync &= enrichPlacementWithRelatedOtherSites(placement);
     doSync &= enrichPlacementWithRelatedGrade(placement);
     doSync &= enrichPlacementWithRelatedSpecialty(placement);
+    doSync &= enrichPlacementWithRelatedOtherSpecialties(placement);
 
     if (doSync) {
       syncPlacement(placement);
@@ -204,6 +206,26 @@ public class PlacementEnricherFacade {
   }
 
   /**
+   * Enrich the placement with details from the Specialty.
+   *
+   * @param data      The data to enrich with specialty data.
+   * @param specialty The specialty to enrich the placement with.
+   * @return Whether enrichment was successful.
+   */
+  private boolean enrich(Map<String, String> data, Specialty specialty) {
+
+    String specialtyName = getSpecialtyName(specialty);
+    String specialtyId = getSpecialtyId(specialty);
+
+    if (specialtyName != null && specialtyId != null) {
+      populateSpecialtyDetails(data, specialtyName, specialtyId);
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Enrich the placement with details from the Grade.
    *
    * @param placement The placement to enrich.
@@ -231,12 +253,6 @@ public class PlacementEnricherFacade {
    * @return Whether enrichment was successful.
    */
   private boolean enrich(Placement placement, Specialty specialty, String placementSpecialtyType) {
-
-    if (placementSpecialtyType.equals(PLACEMENT_SPECIALTY_TYPE_OTHER)) {
-      populateOtherSpecialtyDetails(placement);
-      return true;
-    }
-
     String specialtyName = getSpecialtyName(specialty);
 
     if (specialtyName != null) {
@@ -337,6 +353,52 @@ public class PlacementEnricherFacade {
     return isEnriched;
   }
 
+  /**
+   * Add other specialties data to the placement.
+   *
+   * @param placement The placement to enrich.
+   * @return Whether the placement was enriched, also returns true if no enrichment needed.
+   */
+  private boolean enrichPlacementWithRelatedOtherSpecialties(Placement placement) {
+    boolean isEnriched = true;
+    String placementId = placement.getTisId();
+
+    Set<Map<String, String>> otherSpecialtiesData = new HashSet<>();
+
+    Set<String> otherSpecialtiesIds
+        = placementSpecialtyService.findAllPlacementSpecialtyByPlacementIdAndSpecialtyType(
+            placementId, PLACEMENT_SPECIALTY_TYPE_OTHER).stream()
+        .map(sp -> sp.getData().get(PLACEMENT_SPECIALTY_SPECIALTY_ID_NAME))
+        .filter(Objects::nonNull)
+        .map(Object::toString)
+        .collect(Collectors.toSet());
+
+    for (String otherSpecialtyId : otherSpecialtiesIds) {
+      Optional<Specialty> otherSpecialty = specialtyService.findById(otherSpecialtyId);
+
+      if (otherSpecialty.isPresent()) {
+        Map<String, String> otherSpecialtyData = new HashMap<>();
+        otherSpecialtiesData.add(otherSpecialtyData);
+        isEnriched &= enrich(otherSpecialtyData, otherSpecialty.get());
+      } else {
+        specialtyService.request(otherSpecialtyId);
+        isEnriched = false;
+      }
+    }
+
+    if (isEnriched) {
+      try {
+        String string = objectMapper.writeValueAsString(otherSpecialtiesData);
+        Map<String, String> placementData = placement.getData();
+        placementData.put(PLACEMENT_DATA_OTHER_SPECIALTIES_NAME, string);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException("Unable to process other specialties data.", e);
+      }
+    }
+
+    return isEnriched;
+  }
+
   private boolean enrichPlacementWithRelatedGrade(Placement placement) {
     boolean isEnriched = true;
     String gradeId = getGradeId(placement);
@@ -386,9 +448,6 @@ public class PlacementEnricherFacade {
           .filter(specialty ->
               enrich(placement, specialty, PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY)).isPresent();
     }
-
-    //always rebuild other specialties
-    enrich(placement, null, PLACEMENT_SPECIALTY_TYPE_OTHER);
 
     return isEnriched;
   }
@@ -442,6 +501,24 @@ public class PlacementEnricherFacade {
   }
 
   /**
+   * Enrich the placement with the given specialty name and id and then sync it.
+   *
+   * @param data          The data object to add specialty details to.
+   * @param specialtyName The specialty name to enrich with.
+   * @param specialtyId   The specialty id to enrich with.
+   */
+
+  private void populateSpecialtyDetails(Map<String, String> data, String specialtyName,
+      String specialtyId) {
+    if (Strings.isNotBlank(specialtyName)) {
+      data.put(PLACEMENT_DATA_OTHER_SPECIALTIES_SPECIALTY_NAME, specialtyName);
+    }
+    if (Strings.isNotBlank(specialtyId)) {
+      data.put(PLACEMENT_DATA_OTHER_SPECIALTIES_ID_NAME, specialtyId);
+    }
+  }
+
+  /**
    * Enrich the placement with the given grade name then sync it.
    *
    * @param placement The placement to sync.
@@ -470,29 +547,6 @@ public class PlacementEnricherFacade {
     if (Strings.isNotBlank(subSpecialtyName)) {
       placementData.put(PLACEMENT_DATA_SUB_SPECIALTY_NAME, subSpecialtyName);
     }
-  }
-
-  private void populateOtherSpecialtyDetails(Placement placement) {
-    // Add extra data to placement data.
-    Map<String, String> placementData = placement.getData();
-
-    Set<PlacementSpecialty> otherPlacementSpecialties
-        = placementSpecialtyService.findAllPlacementSpecialtyByPlacementIdAndSpecialtyType(
-            placement.getTisId(), PLACEMENT_SPECIALTY_TYPE_OTHER);
-
-    Set<Specialty> otherSpecialties = new HashSet<>();
-    otherPlacementSpecialties.forEach(ps -> {
-      String specialtyId = ps.getData().get(PLACEMENT_SPECIALTY_SPECIALTY_ID);
-      Optional<Specialty> optionalSpecialty = getSpecialty(specialtyId);
-      optionalSpecialty.ifPresent(otherSpecialties::add);
-    });
-
-    String otherSpecialtyNames = otherSpecialties.stream()
-        .sorted(Comparator.comparing(s -> s.getData().get(SPECIALTY_NAME)))
-        .map(s -> s.getData().get(SPECIALTY_NAME))
-        .collect(Collectors.joining(", "));
-
-    placementData.put(PLACEMENT_DATA_OTHER_SPECIALTIES_NAME, otherSpecialtyNames);
   }
 
   /**
@@ -685,7 +739,17 @@ public class PlacementEnricherFacade {
    * @return The specialty id.
    */
   private String getSpecialtyId(PlacementSpecialty placementSpecialty) {
-    return placementSpecialty.getData().get(PLACEMENT_SPECIALTY_SPECIALITY_ID);
+    return placementSpecialty.getData().get(PLACEMENT_SPECIALTY_SPECIALTY_ID_NAME);
+  }
+
+  /**
+   * Get the Specialty ID from the specialty.
+   *
+   * @param specialty The specialty to get the specialty id from.
+   * @return The specialty id.
+   */
+  private String getSpecialtyId(Specialty specialty) {
+    return specialty.getData().get(SPECIALTY_ID);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -362,7 +362,7 @@ public class PlacementEnricherFacade {
 
     // fetch related Primary Specialty
     Optional<PlacementSpecialty> optionalPrimaryPlacementSpecialty = placementSpecialtyService
-        .findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+        .findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
             placementId, PLACEMENT_SPECIALTY_TYPE_PRIMARY);
     if (optionalPrimaryPlacementSpecialty.isPresent()) {
       Optional<Specialty> optionalPrimarySpecialty =
@@ -378,7 +378,7 @@ public class PlacementEnricherFacade {
 
     // fetch related Sub Specialty (sub specialty is not mandatory)
     Optional<PlacementSpecialty> optionalSubPlacementSpecialty = placementSpecialtyService
-        .findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+        .findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
             placementId, PLACEMENT_SPECIALTY_TYPE_SUB_SPECIALTY);
     if (optionalSubPlacementSpecialty.isPresent()) {
       Optional<Specialty> optionalSubSpecialty =
@@ -481,7 +481,6 @@ public class PlacementEnricherFacade {
     Set<PlacementSpecialty> otherPlacementSpecialties
         = placementSpecialtyService.findAllPlacementSpecialtyByPlacementIdAndSpecialtyType(
             placement.getTisId(), PLACEMENT_SPECIALTY_TYPE_OTHER);
-
 
     Set<Specialty> otherSpecialties = new HashSet<>();
     otherPlacementSpecialties.forEach(ps -> {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacade.java
@@ -217,7 +217,7 @@ public class PlacementEnricherFacade {
     String specialtyName = getSpecialtyName(specialty);
     String specialtyId = getSpecialtyId(specialty);
 
-    if (specialtyName != null && specialtyId != null) {
+    if (specialtyName != null) {
       populateSpecialtyDetails(data, specialtyName, specialtyId);
       return true;
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.ConditionsOfJoining;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.Curricula;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.OtherSites;
+import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.OtherSpecialties;
 import uk.nhs.hee.tis.trainee.sync.mapper.util.TraineeDetailsUtil.WholeTimeEquivalent;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 
@@ -102,7 +103,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "specialty", source = "data.specialty")
   @Mapping(target = "subSpecialty", source = "data.subSpecialty")
   @Mapping(target = "postAllowsSubspecialty", source = "data.postAllowsSubspecialty")
-  @Mapping(target = "otherSpecialties", source = "data.otherSpecialties")
+  @Mapping(target = "otherSpecialties", source = "data", qualifiedBy = OtherSpecialties.class)
   @Mapping(target = "wholeTimeEquivalent", source = "data", qualifiedBy = WholeTimeEquivalent.class)
   TraineeDetailsDto toPlacementDto(Record recrd);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -102,6 +102,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "specialty", source = "data.specialty")
   @Mapping(target = "subSpecialty", source = "data.subSpecialty")
   @Mapping(target = "postAllowsSubspecialty", source = "data.postAllowsSubspecialty")
+  @Mapping(target = "otherSpecialties", source = "data.otherSpecialties")
   @Mapping(target = "wholeTimeEquivalent", source = "data", qualifiedBy = WholeTimeEquivalent.class)
   TraineeDetailsDto toPlacementDto(Record recrd);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/util/TraineeDetailsUtil.java
@@ -64,6 +64,13 @@ public class TraineeDetailsUtil {
   @Qualifier
   @Target(ElementType.METHOD)
   @Retention(RetentionPolicy.SOURCE)
+  public @interface OtherSpecialties {
+
+  }
+
+  @Qualifier
+  @Target(ElementType.METHOD)
+  @Retention(RetentionPolicy.SOURCE)
   public @interface WholeTimeEquivalent {
 
   }
@@ -136,6 +143,29 @@ public class TraineeDetailsUtil {
     }
 
     return otherSites;
+  }
+
+  /**
+   * Gets the set of other specialties from the data map String.
+   *
+   * @param data the data containing the other specialties as a string
+   * @return the other specialties
+   */
+  @OtherSpecialties
+  public Set<Map<String, String>> otherSpecialties(Map<String, String> data) {
+    ObjectMapper mapper = new ObjectMapper();
+
+    Set<Map<String, String>> otherSpecialties = new HashSet<>();
+    if (data.get("otherSpecialties") != null) {
+      try {
+        otherSpecialties = mapper.readValue(data.get("otherSpecialties"), new TypeReference<>() {
+        });
+      } catch (JsonProcessingException e) {
+        log.error("Badly formed other specialties JSON in {}", data);
+      }
+    }
+
+    return otherSpecialties;
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSpecialtyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSpecialtyRepository.java
@@ -40,11 +40,15 @@ public interface PlacementSpecialtyRepository extends MongoRepository<PlacementS
   @Override
   void deleteById(String id);
 
-  @Query("{ $and: [ {'data.placementId' : ?0}, { 'data.placementSpecialtyType' : ?1} ] }")
-  PlacementSpecialty findByPlacementIdAndSpecialtyType(String placementId, String specialtyType);
-
   @Query("{ $and: [ {'data.specialtyId' : ?0}, "
       + "{ $or: [ {'data.placementSpecialtyType' : \"PRIMARY\"}, "
       + "{'data.placementSpecialtyType' : \"SUB_SPECIALTY\"} ] } ] }")
   Set<PlacementSpecialty> findPrimarySubPlacementSpecialtiesBySpecialtyId(String specialtyId);
+
+  @Query("{'data.specialtyId' : ?0}") //TODO: need this annotation?
+  Set<PlacementSpecialty> findBySpecialtyId(String specialtyId);
+
+  @Query("{ $and: [ {'data.placementId' : ?0}, { 'data.placementSpecialtyType' : ?1} ] }")
+  Set<PlacementSpecialty> findAllByPlacementIdAndSpecialtyType(String placementId,
+      String specialtyType);
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSpecialtyRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/PlacementSpecialtyRepository.java
@@ -45,7 +45,7 @@ public interface PlacementSpecialtyRepository extends MongoRepository<PlacementS
       + "{'data.placementSpecialtyType' : \"SUB_SPECIALTY\"} ] } ] }")
   Set<PlacementSpecialty> findPrimarySubPlacementSpecialtiesBySpecialtyId(String specialtyId);
 
-  @Query("{'data.specialtyId' : ?0}") //TODO: need this annotation?
+  @Query("{'data.specialtyId' : ?0}")
   Set<PlacementSpecialty> findBySpecialtyId(String specialtyId);
 
   @Query("{ $and: [ {'data.placementId' : ?0}, { 'data.placementSpecialtyType' : ?1} ] }")

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
@@ -134,7 +134,7 @@ public class PlacementSpecialtySyncService implements SyncService {
     return placementSpecialties.stream().findFirst();
   }
 
-  public Set<PlacementSpecialty> findPlacementSpecialtiesBySpecialtyId(String id) {
+  public Set<PlacementSpecialty> findBySpecialtyId(String id) {
     return repository.findBySpecialtyId(id);
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncService.java
@@ -121,13 +121,13 @@ public class PlacementSpecialtySyncService implements SyncService {
   /**
    * Find a single placement specialty of a given type for a placement. This is primarily a
    * convenience function for finding the at-most single PRIMARY or SUB_SPECIALTY placement
-   * specialty.
+   * specialties; there may be more than one OTHER specialties.
    *
    * @param id The placement id.
    * @param placementSpecialtyType The placement specialty type.
    * @return A single placement specialty, or Optional empty if nothing is found.
    */
-  public Optional<PlacementSpecialty> findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+  public Optional<PlacementSpecialty> findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
       String id, String placementSpecialtyType) {
     Set<PlacementSpecialty> placementSpecialties =
         findAllPlacementSpecialtyByPlacementIdAndSpecialtyType(id, placementSpecialtyType);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/SpecialtySyncService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.tis.trainee.sync.service;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -21,8 +21,6 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
-import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
-
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.model.AmazonSNSException;
 import com.amazonaws.services.sns.model.MessageAttributeValue;

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
-import java.util.Collections;
 import java.util.Set;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +86,7 @@ class SpecialtyEventListenerTest {
     PlacementSpecialty placementSpecialty2 = new PlacementSpecialty();
     placementSpecialty2.setTisId("placementSpecialty2");
 
-    when(placementSpecialtyService.findPlacementSpecialtiesBySpecialtyId("specialty1"))
+    when(placementSpecialtyService.findBySpecialtyId("specialty1"))
         .thenReturn(Set.of(placementSpecialty1, placementSpecialty2));
 
     AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(specialty, null, null);
@@ -128,7 +127,7 @@ class SpecialtyEventListenerTest {
     PlacementSpecialty placementSpecialty2 = new PlacementSpecialty();
     placementSpecialty2.setTisId("placementSpecialty2");
 
-    when(placementSpecialtyService.findPlacementSpecialtiesBySpecialtyId("specialty1"))
+    when(placementSpecialtyService.findBySpecialtyId("specialty1"))
         .thenReturn(Set.of(placementSpecialty1, placementSpecialty2));
 
     AfterDeleteEvent<Specialty> event = new AfterDeleteEvent<>(document, Specialty.class,

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
@@ -87,7 +87,7 @@ class SpecialtyEventListenerTest {
     PlacementSpecialty placementSpecialty2 = new PlacementSpecialty();
     placementSpecialty2.setTisId("placementSpecialty2");
 
-    when(placementSpecialtyService.findPrimaryAndSubPlacementSpecialtiesBySpecialtyId("specialty1"))
+    when(placementSpecialtyService.findPlacementSpecialtiesBySpecialtyId("specialty1"))
         .thenReturn(Set.of(placementSpecialty1, placementSpecialty2));
 
     AfterSaveEvent<Specialty> event = new AfterSaveEvent<>(specialty, null, null);
@@ -128,7 +128,7 @@ class SpecialtyEventListenerTest {
     PlacementSpecialty placementSpecialty2 = new PlacementSpecialty();
     placementSpecialty2.setTisId("placementSpecialty2");
 
-    when(placementSpecialtyService.findPrimaryAndSubPlacementSpecialtiesBySpecialtyId("specialty1"))
+    when(placementSpecialtyService.findPlacementSpecialtiesBySpecialtyId("specialty1"))
         .thenReturn(Set.of(placementSpecialty1, placementSpecialty2));
 
     AfterDeleteEvent<Specialty> event = new AfterDeleteEvent<>(document, Specialty.class,

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
@@ -1015,8 +1015,8 @@ class PlacementEnricherFacadeTest {
     ));
 
     when(siteService.findById(SITE_1_ID)).thenReturn(Optional.of(site));
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
-        any(), any())).thenReturn(null);
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+        any(), any())).thenReturn(Optional.empty());
 
     enricher.enrich(placement);
 
@@ -1088,9 +1088,9 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_1_ID, SPECIALTY_1_TYPE)'
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
-        .thenReturn(placementSpecialty);
+        .thenReturn(Optional.of(placementSpecialty));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty));
 
     enricher.enrich(placement);
@@ -1156,13 +1156,13 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_ID, SPECIALTY_TYPE)'
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
-        .thenReturn(placementSpecialty1);
+        .thenReturn(Optional.of(placementSpecialty1));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty1));
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_2_TYPE))
-        .thenReturn(placementSpecialty2);
+        .thenReturn(Optional.of(placementSpecialty2));
     when(specialtyService.findById(SPECIALTY_2_ID)).thenReturn(Optional.of(specialty2));
 
     enricher.enrich(placement);
@@ -1197,9 +1197,9 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_ID, SPECIALTY_TYPE)'
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
-        .thenReturn(placementSpecialty1);
+        .thenReturn(Optional.of(placementSpecialty1));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty1));
 
     enricher.enrich(placement);
@@ -1255,9 +1255,9 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_1_ID, SPECIALTY_1_TYPE)'
-    when(placementSpecialtyService.findPlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
-        .thenReturn(placementSpecialty);
+        .thenReturn(Optional.of(placementSpecialty));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.empty());
 
     enricher.enrich(placement);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/PlacementEnricherFacadeTest.java
@@ -1015,7 +1015,7 @@ class PlacementEnricherFacadeTest {
     ));
 
     when(siteService.findById(SITE_1_ID)).thenReturn(Optional.of(site));
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         any(), any())).thenReturn(Optional.empty());
 
     enricher.enrich(placement);
@@ -1088,7 +1088,7 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_1_ID, SPECIALTY_1_TYPE)'
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
         .thenReturn(Optional.of(placementSpecialty));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty));
@@ -1156,11 +1156,11 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_ID, SPECIALTY_TYPE)'
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
         .thenReturn(Optional.of(placementSpecialty1));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty1));
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_2_TYPE))
         .thenReturn(Optional.of(placementSpecialty2));
     when(specialtyService.findById(SPECIALTY_2_ID)).thenReturn(Optional.of(specialty2));
@@ -1197,7 +1197,7 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_ID, SPECIALTY_TYPE)'
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
         .thenReturn(Optional.of(placementSpecialty1));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.of(specialty1));
@@ -1255,7 +1255,7 @@ class PlacementEnricherFacadeTest {
     // notes: since each placement can have one PRIMARY and one SUB_SPECIALTY (optional) specialty,
     // placement ID and placement specialty type is used to get the stored placementSpecialty
     // Hence 'findPlacementSpecialtyByPlacementIdAndSpecialtyType(PLACEMENT_1_ID, SPECIALTY_1_TYPE)'
-    when(placementSpecialtyService.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+    when(placementSpecialtyService.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
         PLACEMENT_1_ID, SPECIALTY_1_TYPE))
         .thenReturn(Optional.of(placementSpecialty));
     when(specialtyService.findById(SPECIALTY_1_ID)).thenReturn(Optional.empty());

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapperTest.java
@@ -99,7 +99,7 @@ class TraineeDetailsMapperTest {
 
     TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
 
-    assertThat("Unexpected curricula size.", traineeDetails.getOtherSites().size(), is(0));
+    assertThat("Unexpected other sites size.", traineeDetails.getOtherSites().size(), is(0));
   }
 
   @Test
@@ -109,7 +109,7 @@ class TraineeDetailsMapperTest {
 
     TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
 
-    assertThat("Unexpected curricula size.", traineeDetails.getOtherSites().size(), is(0));
+    assertThat("Unexpected other sites size.", traineeDetails.getOtherSites().size(), is(0));
   }
 
   @Test
@@ -131,5 +131,27 @@ class TraineeDetailsMapperTest {
     TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
 
     assertThat("Unexpected WTE.", traineeDetails.getWholeTimeEquivalent(), is("0.5"));
+  }
+
+  @Test
+  void shouldMapOtherSpecialtiesToEmptySetWhenBadJson() {
+    Record recrd = new Record();
+    recrd.setData(Map.of("otherSpecialties", "bad JSON"));
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected other specialties size.", traineeDetails.getOtherSpecialties().size(),
+        is(0));
+  }
+
+  @Test
+  void shouldMapOtherSpecialtiesToEmptySetWhenMissing() {
+    Record recrd = new Record();
+    recrd.setData(Map.of());
+
+    TraineeDetailsDto traineeDetails = mapper.toPlacementDto(recrd);
+
+    assertThat("Unexpected other specialties size.", traineeDetails.getOtherSpecialties().size(),
+        is(0));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
@@ -301,7 +301,7 @@ class PlacementSpecialtySyncServiceTest {
         .thenReturn(Set.of(placementSpecialty));
 
     Optional<PlacementSpecialty> foundRecord =
-        service.findASinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
+        service.findSinglePlacementSpecialtyByPlacementIdAndSpecialtyType(
             PLACEMENT_ID_1, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY);
     assertThat("Unexpected record.", foundRecord.isPresent(), is(true));
     assertThat("Unexpected record.", foundRecord.get(), is(placementSpecialty));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSpecialtySyncServiceTest.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.tis.trainee.sync.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -63,7 +62,6 @@ import uk.nhs.hee.tis.trainee.sync.repository.PlacementSpecialtyRepository;
 
 class PlacementSpecialtySyncServiceTest {
 
-
   private static final String PLACEMENT_SPECIALTY_ID = "a001";
   private static final String PLACEMENT_ID_1 = "40";
   private static final String PLACEMENT_ID_2 = "140";
@@ -72,6 +70,7 @@ class PlacementSpecialtySyncServiceTest {
 
   private static final String PLACEMENT_SPECIALTY_SPECIALTY_TYPE = "placementSpecialtyType";
   private static final String PLACEMENT_SPECIALTY_PLACEMENT_ID = "placementId";
+  private static final String PLACEMENT_SPECIALTY_SPECIALTY_ID = "specialtyId";
 
   private static final String PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_PRIMARY = "PRIMARY";
   private static final String PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_SUB_SPECIALTY =
@@ -198,6 +197,7 @@ class PlacementSpecialtySyncServiceTest {
     existingPlacementSpecialty.setTisId(PLACEMENT_SPECIALTY_ID);
     existingPlacementSpecialty.setData(new HashMap<>(Map.of(
         PLACEMENT_SPECIALTY_SPECIALTY_TYPE, PLACEMENT_SPECIALTY_DATA_SPECIALTY_TYPE_SUB_SPECIALTY,
+        PLACEMENT_SPECIALTY_SPECIALTY_ID, SPECIALTY_ID_1,
         PLACEMENT_SPECIALTY_PLACEMENT_ID, PLACEMENT_ID_1)));
 
     when(repository.findAllByPlacementIdAndSpecialtyType(
@@ -291,6 +291,18 @@ class PlacementSpecialtySyncServiceTest {
     assertTrue("Unexpected record count.", foundRecord.isPresent());
     assertThat("Unexpected record.", foundRecord.get(), is(placementSpecialty));
     verify(repository).findById(PLACEMENT_ID_1);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindBySpecialtyId() {
+    when(repository.findBySpecialtyId(SPECIALTY_ID_1)).thenReturn(Set.of(placementSpecialty));
+
+    Set<PlacementSpecialty> foundRecords = service.findBySpecialtyId(SPECIALTY_ID_1);
+
+    assertThat("Unexpected record count.", foundRecords.size(), is(1));
+    assertThat("Unexpected record.", foundRecords.iterator().next(), is(placementSpecialty));
+    verify(repository).findBySpecialtyId(SPECIALTY_ID_1);
     verifyNoMoreInteractions(repository);
   }
 


### PR DESCRIPTION
Notes:
* Changes to PlacementSpecialty repository: previously we would hold at most one of each PRIMARY and SUB_SPECIALTY type records for any placement, which enabled searching for a unique record by placement and type. Now there can be multiple records for OTHER-type placement specialties. Note that [placementId + specialtyId] is still guaranteed to be unique.
* The otherSpecialties collection contains documents with specialty Id and specialty name. Note that specialty name is not unique within the specialty collection, hence the need to include the id. This could be extended in future if other attributes are of value.

TIS21-5738