### PR TITLE
fix: initialise new Record child classes with table and schema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.12.1"
+version = "1.12.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapper.java
@@ -69,6 +69,8 @@ public interface ProgrammeMembershipMapper {
 
     UUID uuid = programmeMembership.getUuid();
     programmeMembershipRecord.setTisId(uuid == null ? null : uuid.toString());
+    programmeMembershipRecord.setTable(ProgrammeMembership.ENTITY_NAME);
+    programmeMembershipRecord.setSchema(ProgrammeMembership.SCHEMA_NAME);
     return programmeMembershipRecord;
   }
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
@@ -33,6 +33,9 @@ public class Curriculum extends Record {
   public static final String ENTITY_NAME = "Curriculum";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Curriculum() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class Curriculum extends Record {
 
   public static final String ENTITY_NAME = "Curriculum";
+  public static final String SCHEMA_NAME = "tcs";
 
+  public Curriculum() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Curriculum.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Curriculum entities.
+ */
 @Component(Curriculum.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Curriculum extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
@@ -33,6 +33,9 @@ public class CurriculumMembership extends Record {
   public static final String ENTITY_NAME = "CurriculumMembership";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public CurriculumMembership() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Curriculum membership entities.
+ */
 @Component(CurriculumMembership.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class CurriculumMembership extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembership.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class CurriculumMembership extends Record {
 
   public static final String ENTITY_NAME = "CurriculumMembership";
+  public static final String SCHEMA_NAME = "tcs";
 
+  public CurriculumMembership() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Grade entities.
+ */
 @Component(Grade.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Grade extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
@@ -31,5 +31,12 @@ import org.springframework.stereotype.Component;
 public class Grade extends Record {
 
   public static final String ENTITY_NAME = "Grade";
+  public static final String SCHEMA_NAME = "reference";
+
+  public Grade() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Grade.java
@@ -33,6 +33,9 @@ public class Grade extends Record {
   public static final String ENTITY_NAME = "Grade";
   public static final String SCHEMA_NAME = "reference";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Grade() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
@@ -33,6 +33,9 @@ public class Person extends Record {
   public static final String ENTITY_NAME = "Person";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Person() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
@@ -31,4 +31,11 @@ import org.springframework.stereotype.Component;
 public class Person extends Record {
 
   public static final String ENTITY_NAME = "Person";
+  public static final String SCHEMA_NAME = "tcs";
+
+  public Person() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Person.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Person entities.
+ */
 @Component(Person.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Person extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
@@ -33,6 +33,9 @@ public class Placement extends Record {
   public static final String ENTITY_NAME = "Placement";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Placement() {
     super();
     this.setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Placement entities.
+ */
 @Component(Placement.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Placement extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Placement.java
@@ -31,4 +31,11 @@ import org.springframework.stereotype.Component;
 public class Placement extends Record {
 
   public static final String ENTITY_NAME = "Placement";
+  public static final String SCHEMA_NAME = "tcs";
+
+  public Placement() {
+    super();
+    this.setSchema(SCHEMA_NAME);
+    this.setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
@@ -33,6 +33,9 @@ public class PlacementSpecialty extends Record {
   public static final String ENTITY_NAME = "PlacementSpecialty";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public PlacementSpecialty() {
     super();
     this.setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Placement specialty entities.
+ */
 @Component(PlacementSpecialty.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class PlacementSpecialty extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialty.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class PlacementSpecialty extends Record {
 
   public static final String ENTITY_NAME = "PlacementSpecialty";
+  public static final String SCHEMA_NAME = "tcs";
 
+  public PlacementSpecialty() {
+    super();
+    this.setSchema(SCHEMA_NAME);
+    this.setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
@@ -31,4 +31,11 @@ import org.springframework.stereotype.Component;
 public class Post extends Record {
 
   public static final String ENTITY_NAME = "Post";
+  public static final String SCHEMA_NAME = "tcs";
+
+  public Post() {
+    super();
+    this.setSchema(SCHEMA_NAME);
+    this.setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Post entities.
+ */
 @Component(Post.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Post extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Post.java
@@ -33,6 +33,9 @@ public class Post extends Record {
   public static final String ENTITY_NAME = "Post";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Post() {
     super();
     this.setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class PostSpecialty extends Record {
 
   public static final String ENTITY_NAME = "PostSpecialty";
+  public static final String SCHEMA_NAME = "tcs";
 
+  public PostSpecialty() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Post specialty entities.
+ */
 @Component(PostSpecialty.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class PostSpecialty extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialty.java
@@ -33,6 +33,9 @@ public class PostSpecialty extends Record {
   public static final String ENTITY_NAME = "PostSpecialty";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public PostSpecialty() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
@@ -31,5 +31,12 @@ import org.springframework.stereotype.Component;
 public class Programme extends Record {
 
   public static final String ENTITY_NAME = "Programme";
+  public static final String SCHEMA_NAME = "tcs";
+
+  public Programme() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
@@ -33,6 +33,9 @@ public class Programme extends Record {
   public static final String ENTITY_NAME = "Programme";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Programme() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Programme.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Programme entities.
+ */
 @Component(Programme.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Programme extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
@@ -31,6 +31,7 @@ import org.springframework.data.annotation.Id;
 public class ProgrammeMembership {
 
   public static final String ENTITY_NAME = "ProgrammeMembership";
+  public static final String SCHEMA_NAME = "tcs";
 
   @Id
   private UUID uuid;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeMembership.java
@@ -27,6 +27,9 @@ import java.util.UUID;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 
+/**
+ * A class for TIS Programme membership entities.
+ */
 @Data
 public class ProgrammeMembership {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Site.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Site.java
@@ -33,6 +33,9 @@ public class Site extends Record {
   public static final String ENTITY_NAME = "Site";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Site() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Site.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Site.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Site entities.
+ */
 @Component(Site.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Site extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Specialty entities.
+ */
 @Component(Specialty.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Specialty extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class Specialty extends Record {
 
   public static final String ENTITY_NAME = "Specialty";
+  public static final String SCHEMA_NAME = "tcs";
 
+  public Specialty() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Specialty.java
@@ -33,6 +33,9 @@ public class Specialty extends Record {
   public static final String ENTITY_NAME = "Specialty";
   public static final String SCHEMA_NAME = "tcs";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Specialty() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
@@ -33,6 +33,9 @@ public class Trust extends Record {
   public static final String ENTITY_NAME = "Trust";
   public static final String SCHEMA_NAME = "reference";
 
+  /**
+   * Instantiate with correct default table and schema values.
+   */
   public Trust() {
     super();
     setSchema(SCHEMA_NAME);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
@@ -26,6 +26,9 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+/**
+ * A class for TIS Trust entities.
+ */
 @Component(Trust.ENTITY_NAME)
 @Scope(SCOPE_PROTOTYPE)
 public class Trust extends Record {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Trust.java
@@ -31,5 +31,11 @@ import org.springframework.stereotype.Component;
 public class Trust extends Record {
 
   public static final String ENTITY_NAME = "Trust";
+  public static final String SCHEMA_NAME = "reference";
 
+  public Trust() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingService.java
@@ -41,6 +41,7 @@ public class FifoMessagingService {
 
   private static final String PROGRAMME_MEMBERSHIP_TABLE = "ProgrammeMembership";
   private static final String MESSAGE_GROUP_ID_FORMAT = "%s_%s_%s";
+  protected static final String DEFAULT_SCHEMA = "tcs";
 
   public FifoMessagingService(QueueMessagingTemplate messagingTemplate) {
     this.messagingTemplate = messagingTemplate;
@@ -92,6 +93,7 @@ public class FifoMessagingService {
       };
       return String.format(MESSAGE_GROUP_ID_FORMAT,
           theRecord.getSchema(), groupTableAndId.getFirst(), groupTableAndId.getSecond());
+      //note this assumes the record and its group will always have the same schema
     } else {
       String table = toSendClass.getSimpleName();
       String id = "";
@@ -112,12 +114,13 @@ public class FifoMessagingService {
         };
 
         id = groupTableAndIdMethod.getSecond().invoke(toSend).toString();
-        return String.format(MESSAGE_GROUP_ID_FORMAT, "tcs", groupTableAndIdMethod.getFirst(), id);
+        return String.format(MESSAGE_GROUP_ID_FORMAT,
+            DEFAULT_SCHEMA, groupTableAndIdMethod.getFirst(), id);
       } catch (Exception e) {
         //should not happen
         log.error("Expected id field missing: {}", toSend);
       }
-      return String.format(MESSAGE_GROUP_ID_FORMAT, "tcs", table, id);
+      return String.format(MESSAGE_GROUP_ID_FORMAT, DEFAULT_SCHEMA, table, id);
     }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/ProgrammeMembershipMapperTest.java
@@ -177,6 +177,10 @@ class ProgrammeMembershipMapperTest {
 
     assertThat("Unexpected TIS ID.", programmeMembershipRecord.getTisId(),
         is(UUID_VALUE.toString()));
+    assertThat("Unexpected table.", programmeMembershipRecord.getTable(),
+        is(ProgrammeMembership.ENTITY_NAME));
+    assertThat("Unexpected schema.", programmeMembershipRecord.getSchema(),
+        is(ProgrammeMembership.SCHEMA_NAME));
 
     Map<String, String> recordData = programmeMembershipRecord.getData();
     assertThat("Unexpected uuid.", recordData.get(UUID_FIELD), is(UUID_VALUE.toString()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembershipTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumMembershipTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,20 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class CurriculumMembershipTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    CurriculumMembership curriculumMembership = new CurriculumMembership();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", curriculumMembership.getTable(),
+        is(CurriculumMembership.ENTITY_NAME));
+    assertThat("Unexpected schema.", curriculumMembership.getSchema(),
+        is(CurriculumMembership.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/CurriculumTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class CurriculumTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Curriculum curriculum = new Curriculum();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", curriculum.getTable(), is(Curriculum.ENTITY_NAME));
+    assertThat("Unexpected schema.", curriculum.getSchema(), is(Curriculum.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/GradeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/GradeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class GradeTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Grade grade = new Grade();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", grade.getTable(), is(Grade.ENTITY_NAME));
+    assertThat("Unexpected schema.", grade.getSchema(), is(Grade.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PersonTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PersonTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class PersonTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Person person = new Person();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", person.getTable(), is(Person.ENTITY_NAME));
+    assertThat("Unexpected schema.", person.getSchema(), is(Person.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialtyTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PlacementSpecialtyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,20 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class PlacementSpecialtyTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    PlacementSpecialty placementSpecialty = new PlacementSpecialty();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", placementSpecialty.getTable(),
+        is(PlacementSpecialty.ENTITY_NAME));
+    assertThat("Unexpected schema.", placementSpecialty.getSchema(),
+        is(PlacementSpecialty.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PlacementTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PlacementTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class PlacementTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Placement placement = new Placement();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", placement.getTable(), is(Placement.ENTITY_NAME));
+    assertThat("Unexpected schema.", placement.getSchema(), is(Placement.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialtyTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PostSpecialtyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,20 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class PostSpecialtyTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    PostSpecialty postSpecialty = new PostSpecialty();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", postSpecialty.getTable(),
+        is(PostSpecialty.ENTITY_NAME));
+    assertThat("Unexpected schema.", postSpecialty.getSchema(),
+        is(PostSpecialty.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PostTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/PostTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class PostTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Post post = new Post();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", post.getTable(), is(Post.ENTITY_NAME));
+    assertThat("Unexpected schema.", post.getSchema(), is(Post.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/ProgrammeTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class ProgrammeTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Programme programme = new Programme();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", programme.getTable(), is(Programme.ENTITY_NAME));
+    assertThat("Unexpected schema.", programme.getSchema(), is(Programme.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/SiteTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/SiteTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class SiteTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Site site = new Site();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", site.getTable(), is(Site.ENTITY_NAME));
+    assertThat("Unexpected schema.", site.getSchema(), is(Site.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/SpecialtyTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/SpecialtyTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class SpecialtyTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Specialty specialty = new Specialty();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", specialty.getTable(), is(Specialty.ENTITY_NAME));
+    assertThat("Unexpected schema.", specialty.getSchema(), is(Specialty.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/model/TrustTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/model/TrustTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,21 +21,18 @@
 
 package uk.nhs.hee.tis.trainee.sync.model;
 
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
 
-@Component(Site.ENTITY_NAME)
-@Scope(SCOPE_PROTOTYPE)
-public class Site extends Record {
+class TrustTest {
 
-  public static final String ENTITY_NAME = "Site";
-  public static final String SCHEMA_NAME = "tcs";
+  @Test
+  void shouldInitialiseTableAndSchema() {
+    Trust trust = new Trust();
 
-  public Site() {
-    super();
-    setSchema(SCHEMA_NAME);
-    setTable(ENTITY_NAME);
+    assertThat("Unexpected table.", trust.getTable(), is(Trust.ENTITY_NAME));
+    assertThat("Unexpected schema.", trust.getSchema(), is(Trust.SCHEMA_NAME));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingServiceTest.java
@@ -49,7 +49,7 @@ class FifoMessagingServiceTest {
   private static final String QUEUE = "the-queue";
   private static final String TIS_ID = "tis-id";
   private static final String TABLE = "table";
-  private static final String SCHEMA = "schema";
+  private static final String SCHEMA = "tcs";
 
   private FifoMessagingService service;
   private QueueMessagingTemplate messagingTemplate;
@@ -178,8 +178,6 @@ class FifoMessagingServiceTest {
   void shouldUseProgrammeMembershipForCurriculumMembershipMessageGroupIds() {
     CurriculumMembership curriculumMembership = new CurriculumMembership();
     curriculumMembership.setTisId(TIS_ID);
-    curriculumMembership.setSchema(SCHEMA);
-    curriculumMembership.setTable("CurriculumMembership");
     curriculumMembership.setData(Map.of("programmeMembershipUuid", "UUID"));
 
     String messageGroupId = service.getMessageGroupId(curriculumMembership);
@@ -192,8 +190,6 @@ class FifoMessagingServiceTest {
   void shouldUsePlacementForPlacementSpecialtyMessageGroupIds() {
     PlacementSpecialty placementSpecialty = new PlacementSpecialty();
     placementSpecialty.setTisId(TIS_ID);
-    placementSpecialty.setSchema(SCHEMA);
-    placementSpecialty.setTable("PlacementSpecialty");
     placementSpecialty.setData(Map.of("placementId", "ID"));
 
     String messageGroupId = service.getMessageGroupId(placementSpecialty);


### PR DESCRIPTION
Otherwise the FifoMessagingService.getMessageGroupId() falls over when entities arrive from the event listeners without these basic attributes set (e.g.:
https://github.com/Health-Education-England/tis-trainee-sync/blob/df14a2ef2ab98c1caa69501a04f6c56393a5c50b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java#L65)

TIS21-6040