### PR TITLE
fix: more logging for fifo queues

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/FifoMessagingService.java
@@ -59,6 +59,7 @@ public class FifoMessagingService {
     String messageGroupId = getMessageGroupId(toSend);
     headers.put("message-group-id", messageGroupId);
 
+    log.debug("Sending to FIFO queue {} with headers {}: {}", queueUrl, headers, toSend);
     messagingTemplate.convertAndSend(queueUrl, toSend, headers);
   }
 


### PR DESCRIPTION
Sorry, another one.

Here's another example of the sort of sequence that just... stops... without the placement queue registering that it has received the object

```
2024-06-06 12:55:01.682 DEBUG 1 --- [nerContainer-16] .t.t.s.e.PlacementSpecialtyEventListener : After placement specialty save, search for placement 1996588 to re-sync
2024-06-06 12:55:01.682 DEBUG 1 --- [nerContainer-16] .t.t.s.e.PlacementSpecialtyEventListener : Placement Record(tisId=1996588, data={placementAddedDate=2021-05-13T16:38:18Z, lifecycleState=APPROVED, gradeId=306, siteCode=A89010, postId=30320, dateFrom=2021-08-04, placementWholeTimeEquivalent=1, traineeId=287923, gradeAbbreviation=ST1, placementType=In Post, dateTo=2022-02-01, siteId=3270, placementAmendedDate=2024-06-06T12:43:47Z, id=1996588, employingBodyName=The Lead Employer Trust - NE, trainingBodyName=NHS North East and North Cumbria ICB - 00P, owner=Health Education England North East, postAllowsSubspecialty=false, site=Dr Stephenson & Partners, siteLocation=Victoria Road Health Centre Victoria Road, Concord Washington Tyne & Wear, siteKnownAs=Dr Stephenson & Partners (A89010), otherSites=[{"site":"Sunderland Eye Infirmary","siteLocation":"QUEEN ALEXANDRA ROAD  SUNDERLAND","siteKnownAs":"Sunderland Eye Infirmary (R0B0X)"}], specialty=General Practice, otherSpecialties=[]}, metadata={record-type=data, transaction-id=59545428755495, schema-name=tcs, partition-key-type=schema-table, table-name=Placement, operation=update, timestamp=2024-06-06T12:43:47.857553Z}, type=DATA, operation=LOAD, schema=tcs, table=Placement) found, queuing for re-sync.
2024-06-06 12:55:01.736  INFO 1 --- [nerContainer-16] u.n.h.t.t.sync.service.TcsSyncService    : Trainee details change event sent to SNS.
```
