### PR TITLE
fix: carry training pathway to trainee details

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.13.0"
+version = "1.13.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateProgrammeMembershipDto.java
@@ -42,7 +42,7 @@ public class AggregateProgrammeMembershipDto {
   private LocalDate startDate;
   private LocalDate endDate;
   private LocalDate programmeCompletionDate;
-  private List<AggregateCurriculumMembershipDto> curricula = new ArrayList<>();
   private String trainingPathway;
+  private List<AggregateCurriculumMembershipDto> curricula = new ArrayList<>();
   private ConditionsOfJoiningDto conditionsOfJoining = null;
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/TraineeDetailsDto.java
@@ -98,6 +98,7 @@ public class TraineeDetailsDto {
   private String managingDeanery;
   private String programmeMembershipType;
   private LocalDate programmeCompletionDate;
+  private String trainingPathway;
   private Set<Map<String, String>> curricula;
   private Map<String, String> conditionsOfJoining;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -90,8 +90,8 @@ public interface AggregateMapper {
   @Mapping(target = "programmeNumber", source = "programme.data.programmeNumber")
   @Mapping(target = "managingDeanery", source = "programme.data.owner")
   @Mapping(target = "programmeCompletionDate", ignore = true)
-  @Mapping(target = "curricula", source = "curricula")
   @Mapping(target = "trainingPathway", source = "programmeMembership.trainingPathway")
+  @Mapping(target = "curricula", source = "curricula")
   @Mapping(target = "conditionsOfJoining", source = "conditionsOfJoining")
   AggregateProgrammeMembershipDto toAggregateProgrammeMembershipDto(
       ProgrammeMembership programmeMembership, Programme programme,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/TraineeDetailsMapper.java
@@ -130,6 +130,7 @@ public interface TraineeDetailsMapper {
   @Mapping(target = "programmeTisId", source = "data.programmeTisId")
   @Mapping(target = "managingDeanery", source = "data.managingDeanery")
   @Mapping(target = "programmeCompletionDate", source = "data.programmeCompletionDate")
+  @Mapping(target = "trainingPathway", source = "data.trainingPathway")
   @Mapping(target = "curricula", source = "data", qualifiedBy = Curricula.class)
   @Mapping(target = "conditionsOfJoining", source = "data", qualifiedBy = ConditionsOfJoining.class)
   TraineeDetailsDto toAggregateProgrammeMembershipDto(Record recrd);


### PR DESCRIPTION
The training pathway is lost due to not being mapped back to the TraineeDetailsDto.
Update the DTO to add the training pathway and update the associated mapper configs to ensure it is populated.

Add a new test to TcsSyncServiceTest to verify that programme membership data is patched as expected.

TIS21-6175
TIS21-6181