### PR TITLE
feat: include LocalOffice in sync db

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.14.0"
+version = "1.16.0"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.16.0"
+version = "1.15.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.data.mongodb.core.index.CompoundIndexDefinition;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
@@ -67,6 +68,10 @@ public class MongoConfiguration {
     Index curriculumMembershipCompoundIndex = new CompoundIndexDefinition(cmKeys)
         .named("curriculumMembershipCompoundIndex");
     cmIndexOps.ensureIndex(curriculumMembershipCompoundIndex);
+
+    // LocalOffice
+    IndexOperations localOfficeIndexOps = template.indexOps(LocalOffice.class);
+    localOfficeIndexOps.ensureIndex(new Index().on("data.abbreviation", Direction.ASC));
 
     // Placement
     IndexOperations placementIndexOps = template.indexOps(Placement.class);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.event;
+
+import java.util.Optional;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
+import org.springframework.stereotype.Component;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.Programme;
+import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
+import uk.nhs.hee.tis.trainee.sync.service.LocalOfficeSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
+
+/**
+ * A listener for Mongo events associated with Local office data.
+ */
+@Component
+@Slf4j
+public class LocalOfficeEventListener extends AbstractMongoEventListener<LocalOffice> {
+
+  static final String LOCAL_OFFICE_NAME = "name";
+  private static final String LOCAL_OFFICE_ABBREVIATION = "abbreviation";
+
+  private final LocalOfficeSyncService localOfficeSyncService;
+
+  private final ProgrammeSyncService programmeSyncService;
+
+  private final FifoMessagingService fifoMessagingService;
+
+  private final String programmeQueueUrl;
+
+  private final Cache cache;
+
+  LocalOfficeEventListener(LocalOfficeSyncService localOfficeSyncService,
+      ProgrammeSyncService programmeService,
+      FifoMessagingService fifoMessagingService,
+      @Value("${application.aws.sqs.programme}") String programmeQueueUrl,
+      CacheManager cacheManager) {
+    this.localOfficeSyncService = localOfficeSyncService;
+    this.programmeSyncService = programmeService;
+    this.fifoMessagingService = fifoMessagingService;
+    this.programmeQueueUrl = programmeQueueUrl;
+    cache = cacheManager.getCache(LocalOffice.ENTITY_NAME);
+  }
+
+  @Override
+  public void onAfterSave(AfterSaveEvent<LocalOffice> event) {
+    super.onAfterSave(event);
+
+    LocalOffice localOffice = event.getSource();
+    cache.put(localOffice.getTisId(), localOffice);
+
+    queueRelatedProgrammes(localOffice);
+  }
+
+  /**
+   * Before deleting a LocalOffice, ensure it is cached.
+   *
+   * @param event The before-delete event for the LocalOffice.
+   */
+  @Override
+  public void onBeforeDelete(BeforeDeleteEvent<LocalOffice> event) {
+    String id = event.getSource().getString("_id");
+    LocalOffice localOffice = cache.get(id, LocalOffice.class);
+    if (localOffice == null) {
+      Optional<LocalOffice> newLocalOffice = localOfficeSyncService.findById(id);
+      newLocalOffice.ifPresent(loPresent ->
+          cache.put(id, loPresent));
+    }
+  }
+
+  /**
+   * After delete retrieve cached values and re-sync related Programmes.
+   *
+   * @param event The after-delete event for the DBC.
+   */
+  @Override
+  public void onAfterDelete(AfterDeleteEvent<LocalOffice> event) {
+    super.onAfterDelete(event);
+    LocalOffice localOffice = cache.get(event.getSource().getString("_id"), LocalOffice.class);
+    if (localOffice != null) {
+      queueRelatedProgrammes(localOffice);
+    }
+  }
+
+  /**
+   * Queue the programmes related to the given LocalOffice.
+   *
+   * @param localOffice The LocalOffice to get related programmes for.
+   */
+  private void queueRelatedProgrammes(LocalOffice localOffice) {
+    //If the LO abbreviation changes then that could mean it links to a different DBC
+    //so then the RO could change. This seems quite unlikely but needs to be handled.
+    Set<Programme> programmes =
+        programmeSyncService.findByOwner(localOffice.getData().get(LOCAL_OFFICE_NAME));
+
+    for (Programme programme : programmes) {
+      log.debug("LocalOffice {} affects programme {}, "
+              + "and may require related programme memberships to have RO data amended.",
+          localOffice.getData().get(LOCAL_OFFICE_NAME), programme.getTisId());
+      // Default each message to LOAD.
+      programme.setOperation(Operation.LOAD);
+      String deduplicationId = fifoMessagingService
+          .getUniqueDeduplicationId(Programme.ENTITY_NAME, programme.getTisId());
+      fifoMessagingService.sendMessageToFifoQueue(programmeQueueUrl, programme, deduplicationId);
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
@@ -47,7 +47,6 @@ import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
 public class LocalOfficeEventListener extends AbstractMongoEventListener<LocalOffice> {
 
   static final String LOCAL_OFFICE_NAME = "name";
-  private static final String LOCAL_OFFICE_ABBREVIATION = "abbreviation";
 
   private final LocalOfficeSyncService localOfficeSyncService;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/LocalOffice.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/LocalOffice.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.model;
+
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+/**
+ * A class for TIS reference Local Office entities.
+ */
+@Component(LocalOffice.ENTITY_NAME)
+@Scope(SCOPE_PROTOTYPE)
+public class LocalOffice extends Record {
+
+  public static final String ENTITY_NAME = "LocalOffice";
+  public static final String SCHEMA_NAME = "reference";
+
+  /**
+   * Instantiate with correct default table and schema values.
+   */
+  public LocalOffice() {
+    super();
+    setSchema(SCHEMA_NAME);
+    setTable(ENTITY_NAME);
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/LocalOfficeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/LocalOfficeRepository.java
@@ -27,6 +27,7 @@ import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
 
@@ -41,6 +42,7 @@ public interface LocalOfficeRepository extends MongoRepository<LocalOffice, Stri
   @Override
   Optional<LocalOffice> findById(String id);
 
+  @Query("{ 'data.abbreviation' : ?0}")
   Optional<LocalOffice> findByAbbreviation(String abbreviation);
 
   @CachePut(key = "#entity.tisId")

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/LocalOfficeRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/LocalOfficeRepository.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.repository;
+
+import java.util.Optional;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
+
+/**
+ * A repository for LocalOffice entities.
+ */
+@CacheConfig(cacheNames = LocalOffice.ENTITY_NAME)
+@Repository
+public interface LocalOfficeRepository extends MongoRepository<LocalOffice, String> {
+
+  @Cacheable
+  @Override
+  Optional<LocalOffice> findById(String id);
+
+  Optional<LocalOffice> findByAbbreviation(String abbreviation);
+
+  @CachePut(key = "#entity.tisId")
+  @Override
+  <T extends LocalOffice> T save(T entity);
+
+  @CacheEvict
+  @Override
+  void deleteById(String id);
+
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.LocalOfficeRepository;
+
+/**
+ * A service for managing Local Office synchronisation.
+ */
+@Slf4j
+@Service("reference-LocalOffice")
+public class LocalOfficeSyncService implements SyncService {
+
+  private final LocalOfficeRepository repository;
+
+  private final DataRequestService dataRequestService;
+
+  private final ReferenceSyncService referenceSyncService;
+
+  private final RequestCacheService requestCacheService;
+
+  LocalOfficeSyncService(LocalOfficeRepository repository, DataRequestService dataRequestService,
+      ReferenceSyncService referenceSyncService, RequestCacheService requestCacheService) {
+    this.repository = repository;
+    this.dataRequestService = dataRequestService;
+    this.referenceSyncService = referenceSyncService;
+    this.requestCacheService = requestCacheService;
+  }
+
+  @Override
+  public void syncRecord(Record localOffice) {
+    if (!(localOffice instanceof LocalOffice)) {
+      String message = String.format("Invalid record type '%s'.", localOffice.getClass());
+      throw new IllegalArgumentException(message);
+    }
+
+    if (localOffice.getOperation().equals(DELETE)) {
+      repository.deleteById(localOffice.getTisId());
+    } else {
+      repository.save((LocalOffice) localOffice);
+    }
+
+    requestCacheService.deleteItemFromCache(LocalOffice.ENTITY_NAME, localOffice.getTisId());
+
+    // Send the record to the reference sync service to also be handled as a reference data type.
+    referenceSyncService.syncRecord(localOffice);
+  }
+
+  public Optional<LocalOffice> findById(String id) {
+    return repository.findById(id);
+  }
+
+  public Optional<LocalOffice> findByAbbreviation(String abbr) {
+    return repository.findByAbbreviation(abbr);
+  }
+
+  /**
+   * Make a request to retrieve a specific LocalOffice.
+   *
+   * @param id The id of the LocalOffice to be retrieved.
+   */
+  public void request(String id) {
+    if (!requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, id)) {
+      log.info("Sending request for LocalOffice [{}]", id);
+
+      try {
+        requestCacheService.addItemToCache(LocalOffice.ENTITY_NAME, id,
+            dataRequestService.sendRequest("reference", LocalOffice.ENTITY_NAME, Map.of("id", id)));
+      } catch (JsonProcessingException e) {
+        log.error("Error while trying to retrieve a LocalOffice", e);
+      }
+    } else {
+      log.debug("Already requested LocalOffice [{}].", id);
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/MongoConfigurationTest.java
@@ -39,6 +39,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
@@ -83,6 +84,25 @@ class MongoConfigurationTest {
         hasItems("data.personId", "data.programmeId", "data.programmeMembershipType",
             "data.programmeStartDate", "data.programmeEndDate", "data.programmeMembershipUuid",
             "data.curriculumId"));
+  }
+
+  @Test
+  void shouldInitIndexesForLocalOfficeCollection() {
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(LocalOffice.class)).thenReturn(indexOperations);
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<IndexDefinition> indexes = indexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", indexes.size(), is(1));
+
+    List<String> indexKeys = indexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected index.", indexKeys, hasItems("data.abbreviation"));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListenerTest.java
@@ -47,8 +47,8 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
-import uk.nhs.hee.tis.trainee.sync.service.LocalOfficeSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
+import uk.nhs.hee.tis.trainee.sync.service.LocalOfficeSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
 
 class LocalOfficeEventListenerTest {
@@ -74,8 +74,8 @@ class LocalOfficeEventListenerTest {
     CacheManager cacheManager = mock(CacheManager.class);
     cache = mock(Cache.class);
     when(cacheManager.getCache(LocalOffice.ENTITY_NAME)).thenReturn(cache);
-    listener = new LocalOfficeEventListener(localOfficeService, programmeService, fifoMessagingService,
-        PROGRAMME_QUEUE_URL, cacheManager);
+    listener = new LocalOfficeEventListener(localOfficeService, programmeService,
+        fifoMessagingService, PROGRAMME_QUEUE_URL, cacheManager);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
@@ -169,14 +169,16 @@ class LocalOfficeSyncServiceTest {
   void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(false);
     service.request(ID);
-    verify(dataRequestService).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verify(dataRequestService).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME,
+        whereMap);
   }
 
   @Test
   void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(true);
     service.request(ID);
-    verify(dataRequestService, never()).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verify(dataRequestService, never()).sendRequest(LocalOffice.SCHEMA_NAME,
+        LocalOffice.ENTITY_NAME, whereMap);
     verifyNoMoreInteractions(dataRequestService);
   }
 
@@ -191,7 +193,8 @@ class LocalOfficeSyncServiceTest {
     verify(requestCacheService).deleteItemFromCache(LocalOffice.ENTITY_NAME, ID);
 
     service.request(ID);
-    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME,
+        LocalOffice.ENTITY_NAME, whereMap);
   }
 
   @Test
@@ -213,7 +216,8 @@ class LocalOfficeSyncServiceTest {
     service.request(ID);
     service.request(ID);
 
-    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME,
+        LocalOffice.ENTITY_NAME, whereMap);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
@@ -1,0 +1,217 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMostOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
+import uk.nhs.hee.tis.trainee.sync.model.Operation;
+import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.repository.LocalOfficeRepository;
+
+class LocalOfficeSyncServiceTest {
+
+  public static final String ID_2 = "140";
+  private static final String ID = "40";
+  private LocalOfficeSyncService service;
+
+  private LocalOfficeRepository repository;
+
+  private DataRequestService dataRequestService;
+
+  private ReferenceSyncService referenceSyncService;
+
+  private RequestCacheService requestCacheService;
+
+  private LocalOffice localOffice;
+
+  private Map<String, String> whereMap;
+
+  private Map<String, String> whereMap2;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(LocalOfficeRepository.class);
+    dataRequestService = mock(DataRequestService.class);
+    referenceSyncService = mock(ReferenceSyncService.class);
+    requestCacheService = mock(RequestCacheService.class);
+
+    service = new LocalOfficeSyncService(repository, dataRequestService, referenceSyncService,
+        requestCacheService);
+
+    localOffice = new LocalOffice();
+    localOffice.setTisId(ID);
+
+    whereMap = Map.of("id", ID);
+    whereMap2 = Map.of("id", ID_2);
+  }
+
+  @Test
+  void shouldThrowExceptionIfRecordNotLocalOffice() {
+    Record recrd = new Record();
+    assertThrows(IllegalArgumentException.class, () -> service.syncRecord(recrd));
+  }
+
+  @ParameterizedTest(name = "Should store records when operation is {0}.")
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  void shouldStoreRecords(Operation operation) {
+    localOffice.setOperation(operation);
+
+    service.syncRecord(localOffice);
+
+    verify(repository).save(localOffice);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldDeleteRecordFromStore() {
+    localOffice.setOperation(DELETE);
+
+    service.syncRecord(localOffice);
+
+    verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByIdWhenExists() {
+    when(repository.findById(ID)).thenReturn(Optional.of(localOffice));
+
+    Optional<LocalOffice> found = service.findById(ID);
+    assertThat("Record not found.", found.isPresent(), is(true));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(localOffice));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdWhenNotExists() {
+    when(repository.findById(ID)).thenReturn(Optional.empty());
+
+    Optional<LocalOffice> found = service.findById(ID);
+    assertThat("Record not found.", found.isEmpty(), is(true));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
+    when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(false);
+    service.request(ID);
+    verify(dataRequestService).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+  }
+
+  @Test
+  void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
+    when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(true);
+    service.request(ID);
+    verify(dataRequestService, never()).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verifyNoMoreInteractions(dataRequestService);
+  }
+
+  @Test
+  void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
+    when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(false);
+    service.request(ID);
+    verify(requestCacheService).addItemToCache(eq(LocalOffice.ENTITY_NAME), eq(ID), any());
+
+    localOffice.setOperation(DELETE);
+    service.syncRecord(localOffice);
+    verify(requestCacheService).deleteItemFromCache(LocalOffice.ENTITY_NAME, ID);
+
+    service.request(ID);
+    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+  }
+
+  @Test
+  void shouldSendRequestWhenRequestedDifferentIds() throws JsonProcessingException {
+    service.request(ID);
+    service.request(ID_2);
+
+    verify(dataRequestService, atMostOnce())
+        .sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+    verify(dataRequestService, atMostOnce())
+        .sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap2);
+  }
+
+  @Test
+  void shouldSendRequestWhenFirstRequestFails() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyString(), anyMap());
+
+    service.request(ID);
+    service.request(ID);
+
+    verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
+  }
+
+  @Test
+  void shouldCatchJsonProcessingExceptionIfThrown() throws JsonProcessingException {
+    doThrow(JsonProcessingException.class).when(dataRequestService)
+        .sendRequest(anyString(), anyString(), anyMap());
+    assertDoesNotThrow(() -> service.request(ID));
+  }
+
+  @Test
+  void shouldThrowAnExceptionIfNotJsonProcessingException() throws JsonProcessingException {
+    IllegalStateException illegalStateException = new IllegalStateException("error");
+    doThrow(illegalStateException).when(dataRequestService).sendRequest(anyString(), anyString(),
+        anyMap());
+    assertThrows(IllegalStateException.class, () -> service.request(ID));
+    assertEquals("error", illegalStateException.getMessage());
+  }
+
+  @Test
+  void shouldForwardRecordToReferenceSyncService() {
+    localOffice.setOperation(Operation.LOAD);
+    service.syncRecord(localOffice);
+
+    verify(referenceSyncService).syncRecord(localOffice);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
@@ -141,6 +141,31 @@ class LocalOfficeSyncServiceTest {
   }
 
   @Test
+  void shouldFindRecordByAbbreviationWhenExists() {
+    String abbreviation = "abbr";
+    when(repository.findByAbbreviation(abbreviation)).thenReturn(Optional.of(localOffice));
+
+    Optional<LocalOffice> found = service.findByAbbreviation(abbreviation);
+    assertThat("Record not found.", found.isPresent(), is(true));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(localOffice));
+
+    verify(repository).findByAbbreviation(abbreviation);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByAbbreviationWhenNotExists() {
+    String abbreviation = "abbr";
+    when(repository.findByAbbreviation(abbreviation)).thenReturn(Optional.empty());
+
+    Optional<LocalOffice> found = service.findByAbbreviation(abbreviation);
+    assertThat("Record not found.", found.isEmpty(), is(true));
+
+    verify(repository).findByAbbreviation(abbreviation);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
   void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ID)).thenReturn(false);
     service.request(ID);


### PR DESCRIPTION
This is preliminary work for this ticket, just to get the LocalOffice data into the sync db. The actual linking of the DBC --> LocalOffice --> Programme will be done in a follow-up PR based off https://github.com/Health-Education-England/tis-trainee-sync/pull/465

TIS21-6273