### PR TITLE
feat: DBC / LocalOffice Programme owner refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.16.0"
+version = "1.17.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_NAME;
+
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +52,6 @@ public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
 
   public static final String DBC_NAME = "name";
   public static final String DBC_ABBR = "abbr";
-  public static final String LOCAL_OFFICE_NAME = "name";
 
   private final DbcSyncService dbcSyncService;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
@@ -33,10 +33,12 @@ import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Dbc;
+import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
 import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.DbcSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
+import uk.nhs.hee.tis.trainee.sync.service.LocalOfficeSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
 
 /**
@@ -47,10 +49,13 @@ import uk.nhs.hee.tis.trainee.sync.service.ProgrammeSyncService;
 public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
 
   public static final String DBC_NAME = "name";
+  public static final String DBC_ABBR = "abbr";
+  public static final String LOCAL_OFFICE_NAME = "name";
 
   private final DbcSyncService dbcSyncService;
 
   private final ProgrammeSyncService programmeSyncService;
+  private final LocalOfficeSyncService localOfficeSyncService;
 
   private final FifoMessagingService fifoMessagingService;
 
@@ -59,11 +64,13 @@ public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
   private final Cache cache;
 
   DbcEventListener(DbcSyncService dbcSyncService, ProgrammeSyncService programmeService,
+      LocalOfficeSyncService localOfficeSyncService,
       FifoMessagingService fifoMessagingService,
       @Value("${application.aws.sqs.programme}") String programmeQueueUrl,
       CacheManager cacheManager) {
     this.dbcSyncService = dbcSyncService;
     this.programmeSyncService = programmeService;
+    this.localOfficeSyncService = localOfficeSyncService;
     this.fifoMessagingService = fifoMessagingService;
     this.programmeQueueUrl = programmeQueueUrl;
     cache = cacheManager.getCache(Dbc.ENTITY_NAME);
@@ -115,25 +122,28 @@ public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
    * @param dbc The DBC to get related programmes for.
    */
   private void queueRelatedProgrammes(Dbc dbc) {
-    //NOTE: refactor this as per: https://hee-tis.atlassian.net/browse/TIS21-6228
-    //As a Designated body name will no longer be equal to a Local Office name, and the programme
-    //owner is a Local Office name, the 'findByOwner()' below will become invalid.
-    //This may require
-    // (1) sync LocalOffice into sync db as well as reference.
-    // (2) ensure abbr field is included (its missing from the Reference LocalOffice collection)
-    // (3) join dbc.abbr <-> LocalOffice.abbreviation and use LocalOffice.name <-> Programme.owner
-    Set<Programme> programmes =
-        programmeSyncService.findByOwner(dbc.getData().get(DBC_NAME));
+    String abbr = dbc.getData().get(DBC_ABBR);
+    Optional<LocalOffice> localOfficeOptional = localOfficeSyncService.findByAbbreviation(abbr);
 
-    for (Programme programme : programmes) {
-      log.debug("DBC {} affects programme {}, "
-              + "and will require related programme memberships to have RO data amended.",
-          dbc.getData().get(DBC_NAME), programme.getTisId());
-      // Default each message to LOAD.
-      programme.setOperation(Operation.LOAD);
-      String deduplicationId = fifoMessagingService
-          .getUniqueDeduplicationId(Programme.ENTITY_NAME, programme.getTisId());
-      fifoMessagingService.sendMessageToFifoQueue(programmeQueueUrl, programme, deduplicationId);
+    if (localOfficeOptional.isEmpty()) {
+      log.info("Local office {} not found, requesting data.", abbr);
+      localOfficeSyncService.request(abbr);
+
+    } else {
+
+      Set<Programme> programmes =
+          programmeSyncService.findByOwner(localOfficeOptional.get().getData().get(LOCAL_OFFICE_NAME));
+
+      for (Programme programme : programmes) {
+        log.debug("DBC / LocalOffice {} affects programme {}, "
+                + "and will require related programme memberships to have RO data amended.",
+            dbc.getData().get(DBC_ABBR), programme.getTisId());
+        // Default each message to LOAD.
+        programme.setOperation(Operation.LOAD);
+        String deduplicationId = fifoMessagingService
+            .getUniqueDeduplicationId(Programme.ENTITY_NAME, programme.getTisId());
+        fifoMessagingService.sendMessageToFifoQueue(programmeQueueUrl, programme, deduplicationId);
+      }
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
@@ -128,12 +128,13 @@ public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
 
     if (localOfficeOptional.isEmpty()) {
       log.info("Local office {} not found, requesting data.", abbr);
-      localOfficeSyncService.request(abbr);
+      localOfficeSyncService.requestByAbbr(abbr);
 
     } else {
 
       Set<Programme> programmes =
-          programmeSyncService.findByOwner(localOfficeOptional.get().getData().get(LOCAL_OFFICE_NAME));
+          programmeSyncService.findByOwner(
+              localOfficeOptional.get().getData().get(LOCAL_OFFICE_NAME));
 
       for (Programme programme : programmes) {
         log.debug("DBC / LocalOffice {} affects programme {}, "

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListener.java
@@ -138,7 +138,7 @@ public class UserDesignatedBodyEventListener extends
       if (optionalDbc.isEmpty()) {
         log.info("User designated body {} {} but Dbc not found, requesting data.",
             designatedBodyCodeValue, eventContext);
-        dbcSyncService.request(designatedBodyCodeValue);
+        dbcSyncService.requestByDbc(designatedBodyCodeValue);
       }
     }
   }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/DbcRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/DbcRepository.java
@@ -51,6 +51,15 @@ public interface DbcRepository extends MongoRepository<Dbc, String> {
   @Query("{'data.dbc' : ?0}")
   Optional<Dbc> findByDbc(String dbc);
 
+  /**
+   * Find a DBC with the given abbreviation.
+   *
+   * @param abbr The designated body abbreviation to filter by.
+   * @return The found DBC, or nothing if not found.
+   */
+  @Query("{'data.abbr' : ?0}")
+  Optional<Dbc> findByAbbr(String abbr);
+
   @CachePut(key = "#entity.tisId")
   @Override
   <T extends Dbc> T save(T entity);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncService.java
@@ -99,23 +99,46 @@ public class DbcSyncService implements SyncService {
     return repository.findByDbc(dbc);
   }
 
+  public Optional<Dbc> findByAbbr(String abbr) {
+    return repository.findByAbbr(abbr);
+  }
+
   /**
    * Make a request to retrieve a specific Dbc.
    *
    * @param dbc The designated body code of the Dbc to be retrieved.
    */
-  public void request(String dbc) {
-    if (!requestCacheService.isItemInCache(Dbc.ENTITY_NAME, dbc)) {
-      log.info("Sending request for DBC [{}]", dbc);
+  public void requestByDbc(String dbc) {
+    request("dbc", dbc);
+  }
+
+  /**
+   * Make a request to retrieve a specific Dbc.
+   *
+   * @param abbr The designated body abbreviation of the Dbc to be retrieved.
+   */
+  public void requestByAbbr(String abbr) {
+    request("abbr", abbr);
+  }
+
+  /**
+   * Make a request to retrieve a specific Dbc.
+   *
+   * @param key   The field to filter the Dbc records by.
+   * @param value The field value of the Dbc to be retrieved.
+   */
+  private void request(String key, String value) {
+    if (!requestCacheService.isItemInCache(Dbc.ENTITY_NAME, value)) {
+      log.info("Sending request for DBC [{}]", value);
 
       try {
-        requestCacheService.addItemToCache(Dbc.ENTITY_NAME, dbc,
-            dataRequestService.sendRequest("reference", Dbc.ENTITY_NAME, Map.of("dbc", dbc)));
+        requestCacheService.addItemToCache(Dbc.ENTITY_NAME, value,
+            dataRequestService.sendRequest("reference", Dbc.ENTITY_NAME, Map.of(key, value)));
       } catch (JsonProcessingException e) {
         log.error("Error while trying to retrieve a DBC", e);
       }
     } else {
-      log.debug("Already requested DBC [{}].", dbc);
+      log.debug("Already requested DBC [{}].", value);
     }
   }
 
@@ -143,8 +166,8 @@ public class DbcSyncService implements SyncService {
    * Resync the programmes related to a single user designated body, if the user has a Responsible
    * Officer role.
    *
-   * @param userName The username to filter user designated bodies by.
-   * @param designatedBodyCode  The designated body code to filter user deisngated bodies by.
+   * @param userName           The username to filter user designated bodies by.
+   * @param designatedBodyCode The designated body code to filter user deisngated bodies by.
    */
   public void resyncProgrammesForSingleDbcIfUserIsResponsibleOfficer(String userName,
       String designatedBodyCode) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
@@ -87,7 +87,7 @@ public class LocalOfficeSyncService implements SyncService {
    *
    * @param abbreviation The abbreviation of the LocalOffice to be retrieved.
    */
-  public void request(String abbreviation) {
+  public void requestByAbbr(String abbreviation) {
     if (!requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, abbreviation)) {
       log.info("Sending request for LocalOffice [{}]", abbreviation);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncService.java
@@ -85,20 +85,21 @@ public class LocalOfficeSyncService implements SyncService {
   /**
    * Make a request to retrieve a specific LocalOffice.
    *
-   * @param id The id of the LocalOffice to be retrieved.
+   * @param abbreviation The abbreviation of the LocalOffice to be retrieved.
    */
-  public void request(String id) {
-    if (!requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, id)) {
-      log.info("Sending request for LocalOffice [{}]", id);
+  public void request(String abbreviation) {
+    if (!requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, abbreviation)) {
+      log.info("Sending request for LocalOffice [{}]", abbreviation);
 
       try {
-        requestCacheService.addItemToCache(LocalOffice.ENTITY_NAME, id,
-            dataRequestService.sendRequest("reference", LocalOffice.ENTITY_NAME, Map.of("id", id)));
+        requestCacheService.addItemToCache(LocalOffice.ENTITY_NAME, abbreviation,
+            dataRequestService.sendRequest("reference", LocalOffice.ENTITY_NAME,
+                Map.of("abbreviation", abbreviation)));
       } catch (JsonProcessingException e) {
         log.error("Error while trying to retrieve a LocalOffice", e);
       }
     } else {
-      log.debug("Already requested LocalOffice [{}].", id);
+      log.debug("Already requested LocalOffice [{}].", abbreviation);
     }
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListenerTest.java
@@ -113,7 +113,7 @@ class DbcEventListenerTest {
     Dbc dbc = new Dbc();
     dbc.setTisId(DBC_ID);
     dbc.setData(Map.of("name", "some name", "abbr", ABBR));
-    AfterSaveEvent<Dbc> event = new AfterSaveEvent<>(dbc, null, null);
+    final AfterSaveEvent<Dbc> event = new AfterSaveEvent<>(dbc, null, null);
 
     LocalOffice localOffice = new LocalOffice();
     localOffice.setData(Map.of(LOCAL_OFFICE_NAME, OWNER, "abbr", ABBR));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListenerTest.java
@@ -90,7 +90,7 @@ class UserDesignatedBodyEventListenerTest {
     verify(heeUserService).findByName(USER_NAME_VALUE);
     verify(dbcService).findByDbc(DESIGNATED_BODY_CODE_VALUE);
     verify(heeUserService, never()).request(any());
-    verify(dbcService, never()).request(any());
+    verify(dbcService, never()).requestByDbc(any());
   }
 
   @Test
@@ -126,7 +126,7 @@ class UserDesignatedBodyEventListenerTest {
 
     verify(heeUserService, never()).request(any());
     verify(dbcService).findByDbc(DESIGNATED_BODY_CODE_VALUE);
-    verify(dbcService).request(DESIGNATED_BODY_CODE_VALUE);
+    verify(dbcService).requestByDbc(DESIGNATED_BODY_CODE_VALUE);
     verifyNoMoreInteractions(dbcService);
   }
 
@@ -184,7 +184,7 @@ class UserDesignatedBodyEventListenerTest {
     verify(heeUserService).findByName(USER_NAME_VALUE);
     verify(dbcService).findByDbc(DESIGNATED_BODY_CODE_VALUE);
     verify(heeUserService, never()).request(any());
-    verify(dbcService, never()).request(any());
+    verify(dbcService, never()).requestByDbc(any());
   }
 
   @Test
@@ -228,7 +228,7 @@ class UserDesignatedBodyEventListenerTest {
 
     verify(heeUserService, never()).request(any());
     verify(dbcService).findByDbc(DESIGNATED_BODY_CODE_VALUE);
-    verify(dbcService).request(DESIGNATED_BODY_CODE_VALUE);
+    verify(dbcService).requestByDbc(DESIGNATED_BODY_CODE_VALUE);
     verifyNoMoreInteractions(dbcService);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/LocalOfficeSyncServiceTest.java
@@ -168,7 +168,7 @@ class LocalOfficeSyncServiceTest {
   @Test
   void shouldSendRequestWhenNotAlreadyRequested() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ABBR)).thenReturn(false);
-    service.request(ABBR);
+    service.requestByAbbr(ABBR);
     verify(dataRequestService).sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME,
         whereMap);
   }
@@ -176,7 +176,7 @@ class LocalOfficeSyncServiceTest {
   @Test
   void shouldNotSendRequestWhenAlreadyRequested() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ABBR)).thenReturn(true);
-    service.request(ABBR);
+    service.requestByAbbr(ABBR);
     verify(dataRequestService, never()).sendRequest(LocalOffice.SCHEMA_NAME,
         LocalOffice.ENTITY_NAME, whereMap);
     verifyNoMoreInteractions(dataRequestService);
@@ -185,22 +185,22 @@ class LocalOfficeSyncServiceTest {
   @Test
   void shouldSendRequestWhenSyncedBetweenRequests() throws JsonProcessingException {
     when(requestCacheService.isItemInCache(LocalOffice.ENTITY_NAME, ABBR)).thenReturn(false);
-    service.request(ABBR);
+    service.requestByAbbr(ABBR);
     verify(requestCacheService).addItemToCache(eq(LocalOffice.ENTITY_NAME), eq(ABBR), any());
 
     localOffice.setOperation(DELETE);
     service.syncRecord(localOffice);
     verify(requestCacheService).deleteItemFromCache(LocalOffice.ENTITY_NAME, ID);
 
-    service.request(ABBR);
+    service.requestByAbbr(ABBR);
     verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME,
         LocalOffice.ENTITY_NAME, whereMap);
   }
 
   @Test
   void shouldSendRequestWhenRequestedDifferentIds() throws JsonProcessingException {
-    service.request(ABBR);
-    service.request(ABBR_2);
+    service.requestByAbbr(ABBR);
+    service.requestByAbbr(ABBR_2);
 
     verify(dataRequestService, atMostOnce())
         .sendRequest(LocalOffice.SCHEMA_NAME, LocalOffice.ENTITY_NAME, whereMap);
@@ -213,8 +213,8 @@ class LocalOfficeSyncServiceTest {
     doThrow(JsonProcessingException.class).when(dataRequestService)
         .sendRequest(anyString(), anyString(), anyMap());
 
-    service.request(ABBR);
-    service.request(ABBR);
+    service.requestByAbbr(ABBR);
+    service.requestByAbbr(ABBR);
 
     verify(dataRequestService, times(2)).sendRequest(LocalOffice.SCHEMA_NAME,
         LocalOffice.ENTITY_NAME, whereMap);
@@ -224,7 +224,7 @@ class LocalOfficeSyncServiceTest {
   void shouldCatchJsonProcessingExceptionIfThrown() throws JsonProcessingException {
     doThrow(JsonProcessingException.class).when(dataRequestService)
         .sendRequest(anyString(), anyString(), anyMap());
-    assertDoesNotThrow(() -> service.request(ABBR));
+    assertDoesNotThrow(() -> service.requestByAbbr(ABBR));
   }
 
   @Test
@@ -232,7 +232,7 @@ class LocalOfficeSyncServiceTest {
     IllegalStateException illegalStateException = new IllegalStateException("error");
     doThrow(illegalStateException).when(dataRequestService).sendRequest(anyString(), anyString(),
         anyMap());
-    assertThrows(IllegalStateException.class, () -> service.request(ABBR));
+    assertThrows(IllegalStateException.class, () -> service.requestByAbbr(ABBR));
     assertEquals("error", illegalStateException.getMessage());
   }
 


### PR DESCRIPTION
For context see (now removed) comment:
```
    //NOTE: refactor this as per: https://hee-tis.atlassian.net/browse/TIS21-6228
    //As a Designated body name will no longer be equal to a Local Office name, and the programme
    //owner is a Local Office name, the 'findByOwner()' below will become invalid.
    //This may require
    // (1) sync LocalOffice into sync db as well as reference.
    // (2) ensure abbr field is included (its missing from the Reference LocalOffice collection)
    // (3) join dbc.abbr <-> LocalOffice.abbreviation and use LocalOffice.name <-> Programme.owner
```

Dependent on
https://github.com/Health-Education-England/TIS-REFERENCE/pull/343 and https://github.com/Health-Education-England/TIS-SYNC/pull/253

TIS21-6273