### PR TITLE
fix: ignore irrelevant DBCs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.17.0"
+version = "1.17.1"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
To avoid requesting 'related' local offices for DBCs that will never be linked to one.

TIS21-6272