### PR TITLE
fix: do not requeue old placement data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.18.2"
+version = "1.18.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ConditionsOfJoiningEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ConditionsOfJoiningEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -35,7 +37,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.tis.trainee.sync.model.ConditionsOfJoining;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.service.ConditionsOfJoiningSyncService;
@@ -162,7 +163,7 @@ public class ConditionsOfJoiningEventListener
       Record programmeMembershipRecord = programmeMembershipMapper.toRecord(
           programmeMembership.get());
       // Default the message to LOOKUP.
-      programmeMembershipRecord.setOperation(Operation.LOOKUP);
+      programmeMembershipRecord.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService.getUniqueDeduplicationId("ProgrammeMembership",
           String.valueOf(programmeMembership.get().getUuid()));
       fifoMessagingService.sendMessageToFifoQueue(programmeMembershipQueueUrl,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
@@ -30,7 +32,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
 
@@ -66,8 +67,8 @@ public class CurriculumEventListener extends AbstractMongoEventListener<Curricul
         curriculumMembershipService.findByCurriculumId(curriculum.getTisId());
 
     for (CurriculumMembership curriculumMembership : curriculumMemberships) {
-      // Default each message to LOAD.
-      curriculumMembership.setOperation(Operation.LOAD);
+      // Default each message to LOOKUP.
+      curriculumMembership.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("CurriculumMembership", curriculumMembership.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(curriculumMembershipQueueUrl,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,7 +35,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
@@ -130,7 +131,7 @@ public class CurriculumMembershipEventListener
       Record programmeMembershipRecord = programmeMembershipMapper.toRecord(
           programmeMembership.get());
       // Default the message to LOOKUP.
-      programmeMembershipRecord.setOperation(Operation.LOOKUP);
+      programmeMembershipRecord.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService.getUniqueDeduplicationId(
           "ProgrammeMembership", String.valueOf(programmeMembership.get().getUuid()));
       fifoMessagingService.sendMessageToFifoQueue(programmeMembershipQueueUrl,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListener.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.tis.trainee.sync.event;
 
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Optional;
 import java.util.Set;
@@ -36,7 +37,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Dbc;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.DbcSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -145,8 +145,8 @@ public class DbcEventListener extends AbstractMongoEventListener<Dbc> {
           log.debug("DBC / LocalOffice {} affects programme {}, "
                   + "and will require related programme memberships to have RO data amended.",
               dbc.getData().get(DBC_ABBR), programme.getTisId());
-          // Default each message to LOAD.
-          programme.setOperation(Operation.LOAD);
+          // Default each message to LOOKUP.
+          programme.setOperation(LOOKUP);
           String deduplicationId = fifoMessagingService
               .getUniqueDeduplicationId(Programme.ENTITY_NAME, programme.getTisId());
           fifoMessagingService.sendMessageToFifoQueue(programmeQueueUrl, programme,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListener.java
@@ -57,8 +57,8 @@ public class GradeEventListener extends AbstractMongoEventListener<Grade> {
     Set<Placement> placements = placementService.findByGradeId(grade.getTisId());
 
     for (Placement placement : placements) {
-      // Default each placement to LOAD.
-      placement.setOperation(Operation.LOAD);
+      // Default each placement to LOOKUP.
+      placement.setOperation(Operation.LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListener.java
@@ -21,13 +21,14 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Grade;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
@@ -58,7 +59,7 @@ public class GradeEventListener extends AbstractMongoEventListener<Grade> {
 
     for (Placement placement : placements) {
       // Default each placement to LOOKUP.
-      placement.setOperation(Operation.LOOKUP);
+      placement.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +36,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.model.Dbc;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.DbcSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -140,8 +141,8 @@ public class LocalOfficeEventListener extends AbstractMongoEventListener<LocalOf
         log.debug("LocalOffice {} affects programme {}, "
                 + "and may require related programme memberships to have RO data amended.",
             localOffice.getData().get(LOCAL_OFFICE_NAME), programme.getTisId());
-        // Default each message to LOAD.
-        programme.setOperation(Operation.LOAD);
+        // Default each message to LOOKUP.
+        programme.setOperation(LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId(Programme.ENTITY_NAME, programme.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(programmeQueueUrl, programme, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
@@ -88,9 +88,9 @@ public class PlacementSiteEventListener extends AbstractMongoEventListener<Place
     if (optionalPlacement.isPresent()) {
       log.debug("Placement {} found, queuing for re-sync.", placementId);
 
-      // Default the placement to LOAD.
+      // Default the placement to LOOKUP.
       Placement placement = optionalPlacement.get();
-      placement.setOperation(Operation.LOAD);
+      placement.setOperation(Operation.LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);
@@ -135,9 +135,9 @@ public class PlacementSiteEventListener extends AbstractMongoEventListener<Place
       if (optionalPlacement.isPresent()) {
         log.debug("Placement {} found, queuing for re-sync.", placementId);
 
-        // Default the placement to LOAD.
+        // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
-        placement.setOperation(Operation.LOAD);
+        placement.setOperation(Operation.LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +33,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -90,7 +91,7 @@ public class PlacementSiteEventListener extends AbstractMongoEventListener<Place
 
       // Default the placement to LOOKUP.
       Placement placement = optionalPlacement.get();
-      placement.setOperation(Operation.LOOKUP);
+      placement.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);
@@ -137,7 +138,7 @@ public class PlacementSiteEventListener extends AbstractMongoEventListener<Place
 
         // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
-        placement.setOperation(Operation.LOOKUP);
+        placement.setOperation(LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
@@ -78,10 +78,10 @@ public class PlacementSpecialtyEventListener extends
       Optional<Placement> optionalPlacement = placementService.findById(placementId);
       log.debug("After placement specialty save, search for placement {} to re-sync", placementId);
       if (optionalPlacement.isPresent()) {
-        // Default the placement to LOAD.
+        // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
         log.debug("Placement {} found, queuing for re-sync.", placement);
-        placement.setOperation(Operation.LOAD);
+        placement.setOperation(Operation.LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);
@@ -123,10 +123,10 @@ public class PlacementSpecialtyEventListener extends
       log.debug("After placement specialty delete, search for placement {} to re-sync.",
           placementId);
       if (optionalPlacement.isPresent()) {
-        // Default the placement to LOAD.
+        // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
         log.debug("Placement {} found, queuing for re-sync.", placement);
-        placement.setOperation(Operation.LOAD);
+        placement.setOperation(Operation.LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +33,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -81,7 +82,7 @@ public class PlacementSpecialtyEventListener extends
         // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
         log.debug("Placement {} found, queuing for re-sync.", placement);
-        placement.setOperation(Operation.LOOKUP);
+        placement.setOperation(LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);
@@ -126,7 +127,7 @@ public class PlacementSpecialtyEventListener extends
         // Default the placement to LOOKUP.
         Placement placement = optionalPlacement.get();
         log.debug("Placement {} found, queuing for re-sync.", placement);
-        placement.setOperation(Operation.LOOKUP);
+        placement.setOperation(LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Placement", placement.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
@@ -57,8 +57,8 @@ public class PostEventListener extends AbstractMongoEventListener<Post> {
     Set<Placement> placements = placementService.findByPostId(post.getTisId());
 
     for (Placement placement : placements) {
-      // Default each placement to LOAD.
-      placement.setOperation(Operation.LOAD);
+      // Default each placement to LOOKUP.
+      placement.setOperation(Operation.LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListener.java
@@ -21,12 +21,13 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -58,7 +59,7 @@ public class PostEventListener extends AbstractMongoEventListener<Post> {
 
     for (Placement placement : placements) {
       // Default each placement to LOOKUP.
-      placement.setOperation(Operation.LOOKUP);
+      placement.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostSpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/PostSpecialtyEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,7 +33,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.model.PostSpecialty;
 import uk.nhs.hee.tis.trainee.sync.model.Specialty;
@@ -63,7 +64,7 @@ public class PostSpecialtyEventListener extends AbstractMongoEventListener<PostS
    * @param postService          The post service.
    * @param specialtyService     The specialty service.
    * @param postSpecialtyService The post specialty service.
-   * @param fifoMessagingService    FIFO queue service for placement expansion.
+   * @param fifoMessagingService FIFO queue service for placement expansion.
    * @param cacheManager         The cache for deleted records.
    * @param postQueueUrl         The queue to expand posts into.
    */
@@ -98,7 +99,7 @@ public class PostSpecialtyEventListener extends AbstractMongoEventListener<PostS
       log.debug("Post {} found, queuing for re-sync.", postId);
 
       Post post = postOptional.get();
-      post.setOperation(Operation.LOAD);
+      post.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Post", post.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(postQueueUrl, post, deduplicationId);
@@ -156,7 +157,7 @@ public class PostSpecialtyEventListener extends AbstractMongoEventListener<PostS
         log.debug("Post {} found, queuing for re-sync.", postId);
 
         Post post = postOptional.get();
-        post.setOperation(Operation.LOAD);
+        post.setOperation(LOOKUP);
         String deduplicationId = fifoMessagingService
             .getUniqueDeduplicationId("Post", post.getTisId());
         fifoMessagingService.sendMessageToFifoQueue(postQueueUrl, post, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListener.java
@@ -21,13 +21,14 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapper;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
@@ -67,7 +68,7 @@ public class ProgrammeEventListener extends AbstractMongoEventListener<Programme
 
     for (Record programmeMembership : programmeMembershipMapper.toRecords(programmeMemberships)) {
       // Default each message to LOOKUP.
-      programmeMembership.setOperation(Operation.LOOKUP);
+      programmeMembership.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("ProgrammeMembership", programmeMembership.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(programmeMembershipQueueUrl, programmeMembership,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -29,7 +31,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.model.Site;
@@ -84,7 +85,7 @@ public class SiteEventListener extends AbstractMongoEventListener<Site> {
     for (Placement placement : placements) {
       log.debug("Placement {} found, queuing for re-sync.", placement.getTisId());
       // Default each placement to LOOKUP.
-      placement.setOperation(Operation.LOOKUP);
+      placement.setOperation(LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListener.java
@@ -83,8 +83,8 @@ public class SiteEventListener extends AbstractMongoEventListener<Site> {
 
     for (Placement placement : placements) {
       log.debug("Placement {} found, queuing for re-sync.", placement.getTisId());
-      // Default each placement to LOAD.
-      placement.setOperation(Operation.LOAD);
+      // Default each placement to LOOKUP.
+      placement.setOperation(Operation.LOOKUP);
       String deduplicationId = fifoMessagingService
           .getUniqueDeduplicationId("Placement", placement.getTisId());
       fifoMessagingService.sendMessageToFifoQueue(placementQueueUrl, placement, deduplicationId);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
@@ -64,8 +66,8 @@ public class SpecialtyEventListener extends AbstractMongoEventListener<Specialty
     super.onAfterSave(event);
 
     Specialty specialty = event.getSource();
-    sendPlacementSpecialtyMessages(specialty.getTisId(), Operation.LOAD);
-    sendPostSubSpecialtyMessages(specialty.getTisId(), Operation.LOAD);
+    sendPlacementSpecialtyMessages(specialty.getTisId(), LOOKUP);
+    sendPostSubSpecialtyMessages(specialty.getTisId(), LOOKUP);
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListener.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.event;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
+
 import java.util.HashSet;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,7 +58,7 @@ public class TrustEventListener extends AbstractMongoEventListener<Trust> {
     super.onAfterSave(event);
 
     Trust trust = event.getSource();
-    sendPostMessages(trust.getTisId(), Operation.LOAD);
+    sendPostMessages(trust.getTisId(), LOOKUP);
   }
 
   @Override

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
@@ -39,7 +39,6 @@ import uk.nhs.hee.tis.trainee.sync.dto.AggregateCurriculumMembershipDto;
 import uk.nhs.hee.tis.trainee.sync.dto.AggregateProgrammeMembershipDto;
 import uk.nhs.hee.tis.trainee.sync.dto.ProgrammeMembershipEventDto;
 import uk.nhs.hee.tis.trainee.sync.mapper.AggregateMapper;
-import uk.nhs.hee.tis.trainee.sync.mapper.HeeUserMapper;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipEventMapper;
 import uk.nhs.hee.tis.trainee.sync.model.ConditionsOfJoining;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
@@ -178,7 +177,7 @@ public class ProgrammeMembershipEnricherFacade {
    *
    * @param programmeMembership The programme membership to get the curriculum memberships for.
    * @return The list of aggregated curriculum membership data, or an empty list if not all data was
-   *     available.
+   * available.
    */
   private List<AggregateCurriculumMembershipDto> buildCurriculumMemberships(
       ProgrammeMembership programmeMembership) {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ConditionsOfJoiningEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ConditionsOfJoiningEventListenerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.AssertionErrors.assertNotNull;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -48,7 +49,6 @@ import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.tis.trainee.sync.model.ConditionsOfJoining;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.service.ConditionsOfJoiningSyncService;
@@ -105,7 +105,7 @@ class ConditionsOfJoiningEventListenerTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setUuid(pmUuid);
     Record programmeMembershipRecord = programmeMembershipMapper.toRecord(programmeMembership);
-    programmeMembershipRecord.setOperation(Operation.LOOKUP);
+    programmeMembershipRecord.setOperation(LOOKUP);
 
     ConditionsOfJoining conditionsOfJoining = new ConditionsOfJoining();
     conditionsOfJoining.setProgrammeMembershipUuid(pmUuid.toString());
@@ -121,8 +121,7 @@ class ConditionsOfJoiningEventListenerTest {
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_MEMBERSHIP_QUEUE_URL), eq(programmeMembershipRecord), any());
 
-    assertThat("Unexpected operation.", programmeMembershipRecord.getOperation(),
-        is(Operation.LOOKUP));
+    assertThat("Unexpected operation.", programmeMembershipRecord.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -206,7 +205,7 @@ class ConditionsOfJoiningEventListenerTest {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setUuid(pmUuid);
     Record programmeMembershipRecord = programmeMembershipMapper.toRecord(programmeMembership);
-    programmeMembershipRecord.setOperation(Operation.LOOKUP);
+    programmeMembershipRecord.setOperation(LOOKUP);
 
     when(programmeMembershipSyncService.findById(pmUuid.toString()))
         .thenReturn(Optional.of(programmeMembership));
@@ -220,8 +219,7 @@ class ConditionsOfJoiningEventListenerTest {
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_MEMBERSHIP_QUEUE_URL), eq(programmeMembershipRecord), any());
 
-    assertThat("Unexpected operation.", programmeMembershipRecord.getOperation(),
-        is(Operation.LOOKUP));
+    assertThat("Unexpected operation.", programmeMembershipRecord.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumEventListenerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Set;
@@ -40,7 +41,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.model.Curriculum;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
 
@@ -112,12 +112,10 @@ class CurriculumEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(CURRICULUM_MEMBERSHIP_QUEUE_URL), eq(curriculumMembership1), any());
-    assertThat("Unexpected table operation.", curriculumMembership1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", curriculumMembership1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(CURRICULUM_MEMBERSHIP_QUEUE_URL), eq(curriculumMembership2), any());
-    assertThat("Unexpected table operation.", curriculumMembership2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", curriculumMembership2.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/CurriculumMembershipEventListenerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -48,7 +49,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.tis.trainee.sync.model.CurriculumMembership;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.service.CurriculumMembershipSyncService;
@@ -138,7 +138,7 @@ class CurriculumMembershipEventListenerTest {
     Record theRecord = recordCaptor.getValue();
     assertThat("Unexpected TIS ID.", theRecord.getTisId(),
         is(programmeMembershipUuid.toString()));
-    assertThat("Unexpected table operation.", theRecord.getOperation(), is(Operation.LOOKUP));
+    assertThat("Unexpected table operation.", theRecord.getOperation(), is(LOOKUP));
 
     Map<String, String> data = theRecord.getData();
     assertThat("Unexpected date count.", data.size(), is(13));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/DbcEventListenerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.event.DbcEventListener.DBC_TYPE;
 import static uk.nhs.hee.tis.trainee.sync.event.DbcEventListener.DBC_TYPE_RELEVANT;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Map;
@@ -48,7 +49,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import uk.nhs.hee.tis.trainee.sync.model.Dbc;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.DbcSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -155,13 +155,11 @@ class DbcEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme1), any());
-    assertThat("Unexpected table operation.", programme1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme2), any());
-    assertThat("Unexpected table operation.", programme2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme2.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -220,13 +218,11 @@ class DbcEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme1), any());
-    assertThat("Unexpected table operation.", programme1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme2), any());
-    assertThat("Unexpected table operation.", programme2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme2.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/GradeEventListenerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Set;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.model.Grade;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
 import uk.nhs.hee.tis.trainee.sync.service.PlacementSyncService;
@@ -86,10 +86,10 @@ class GradeEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement2), any());
-    assertThat("Unexpected table operation.", placement2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement2.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/LocalOfficeEventListenerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_ABBREVIATION;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Map;
@@ -47,7 +48,6 @@ import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
 import uk.nhs.hee.tis.trainee.sync.model.Dbc;
 import uk.nhs.hee.tis.trainee.sync.model.LocalOffice;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.service.DbcSyncService;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -143,13 +143,11 @@ class LocalOfficeEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme1), any());
-    assertThat("Unexpected table operation.", programme1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme2), any());
-    assertThat("Unexpected table operation.", programme2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme2.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -210,13 +208,11 @@ class LocalOfficeEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme1), any());
-    assertThat("Unexpected table operation.", programme1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PROGRAMME_QUEUE_URL), eq(programme2), any());
-    assertThat("Unexpected table operation.", programme2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", programme2.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSiteEventListenerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Optional;
 import org.bson.Document;
@@ -41,7 +42,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -104,7 +104,7 @@ class PlacementSiteEventListenerTest {
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement), any());
 
-    assertThat("Unexpected operation.", placement.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected operation.", placement.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -189,6 +189,6 @@ class PlacementSiteEventListenerTest {
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement), any());
 
-    assertThat("Unexpected operation.", placement.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected operation.", placement.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PlacementSpecialtyEventListenerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,7 +46,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSpecialty;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -108,7 +108,7 @@ class PlacementSpecialtyEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement), any());
-    assertThat("Unexpected table operation.", placement.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement.getOperation(), is(LOOKUP));
     verify(placementService, never()).request(PLACEMENT_ID);
   }
 
@@ -198,6 +198,6 @@ class PlacementSpecialtyEventListenerTest {
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement), any());
 
-    assertThat("Unexpected operation.", placement.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected operation.", placement.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostEventListenerTest.java
@@ -29,13 +29,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.service.FifoMessagingService;
@@ -86,10 +86,10 @@ class PostEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement2), any());
-    assertThat("Unexpected table operation.", placement2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement2.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostSpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/PostSpecialtyEventListenerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +43,6 @@ import org.springframework.cache.CacheManager;
 import org.springframework.data.mongodb.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import org.springframework.data.mongodb.core.mapping.event.BeforeDeleteEvent;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Post;
 import uk.nhs.hee.tis.trainee.sync.model.PostSpecialty;
 import uk.nhs.hee.tis.trainee.sync.model.Specialty;
@@ -150,7 +150,7 @@ class PostSpecialtyEventListenerTest {
     verify(postService, never()).request(any());
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_QUEUE_URL), eq(post), any());
-    assertThat("Unexpected table operation.", post.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", post.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -215,7 +215,7 @@ class PostSpecialtyEventListenerTest {
     verify(postService, never()).request(any());
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_QUEUE_URL), eq(post), any());
-    assertThat("Unexpected table operation.", post.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", post.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/ProgrammeEventListenerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -44,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
 import uk.nhs.hee.tis.trainee.sync.mapper.ProgrammeMembershipMapperImpl;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Programme;
 import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
@@ -119,7 +119,7 @@ class ProgrammeEventListenerTest {
     Record theRecord = recordCaptor.getValue();
     assertThat("Unexpected TIS ID.", theRecord.getTisId(),
         is(programmeMembershipUuid.toString()));
-    assertThat("Unexpected table operation.", theRecord.getOperation(), is(Operation.LOOKUP));
+    assertThat("Unexpected table operation.", theRecord.getOperation(), is(LOOKUP));
 
     Map<String, String> data = theRecord.getData();
     assertThat("Unexpected date count.", data.size(), is(13));
@@ -173,7 +173,7 @@ class ProgrammeEventListenerTest {
         .filter(r -> r.getTisId().equals(programmeMembershipUuid1.toString())).findFirst()
         .orElse(null);
     assertThat("Unexpected TIS ID.", theRecord.getTisId(), is(programmeMembershipUuid1.toString()));
-    assertThat("Unexpected table operation.", theRecord.getOperation(), is(Operation.LOOKUP));
+    assertThat("Unexpected table operation.", theRecord.getOperation(), is(LOOKUP));
 
     Map<String, String> data = theRecord.getData();
     assertThat("Unexpected UUID.", data.get("uuid"), is(programmeMembershipUuid1.toString()));
@@ -182,7 +182,7 @@ class ProgrammeEventListenerTest {
     theRecord = records.stream().filter(
         r -> r.getTisId().equals(programmeMembershipUuid2.toString())).findFirst().orElse(null);
     assertThat("Unexpected TIS ID.", theRecord.getTisId(), is(programmeMembershipUuid2.toString()));
-    assertThat("Unexpected table operation.", theRecord.getOperation(), is(Operation.LOOKUP));
+    assertThat("Unexpected table operation.", theRecord.getOperation(), is(LOOKUP));
 
     data = theRecord.getData();
     assertThat("Unexpected UUID.", data.get("uuid"), is(programmeMembershipUuid2.toString()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SiteEventListenerTest.java
@@ -29,13 +29,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
-import uk.nhs.hee.tis.trainee.sync.model.Operation;
 import uk.nhs.hee.tis.trainee.sync.model.Placement;
 import uk.nhs.hee.tis.trainee.sync.model.PlacementSite;
 import uk.nhs.hee.tis.trainee.sync.model.Site;
@@ -99,11 +99,11 @@ class SiteEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement2), any());
-    assertThat("Unexpected table operation.", placement2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement2.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -130,7 +130,7 @@ class SiteEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(placementService).request(PLACEMENT_ID_2);
   }
@@ -161,11 +161,11 @@ class SiteEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement2), any());
-    assertThat("Unexpected table operation.", placement2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement2.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -191,10 +191,10 @@ class SiteEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement1), any());
-    assertThat("Unexpected table operation.", placement1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_QUEUE_URL), eq(placement2), any());
-    assertThat("Unexpected table operation.", placement2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placement2.getOperation(), is(LOOKUP));
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/SpecialtyEventListenerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Set;
 import org.bson.Document;
@@ -96,13 +97,11 @@ class SpecialtyEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_SPECIALTY_QUEUE_URL), eq(placementSpecialty1), any());
-    assertThat("Unexpected table operation.", placementSpecialty1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placementSpecialty1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(PLACEMENT_SPECIALTY_QUEUE_URL), eq(placementSpecialty2), any());
-    assertThat("Unexpected table operation.", placementSpecialty2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", placementSpecialty2.getOperation(), is(LOOKUP));
   }
 
   @Test
@@ -182,13 +181,11 @@ class SpecialtyEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_SPECIALTY_QUEUE_URL), eq(postSpecialty1), any());
-    assertThat("Unexpected table operation.", postSpecialty1.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", postSpecialty1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_SPECIALTY_QUEUE_URL), eq(postSpecialty2), any());
-    assertThat("Unexpected table operation.", postSpecialty2.getOperation(),
-        is(Operation.LOAD));
+    assertThat("Unexpected table operation.", postSpecialty2.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/TrustEventListenerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
 
 import java.util.Collections;
 import java.util.Set;
@@ -93,15 +94,15 @@ class TrustEventListenerTest {
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_QUEUE_URL), eq(post1), any());
-    assertThat("Unexpected table operation.", post1.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", post1.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_QUEUE_URL), eq(post2), any());
-    assertThat("Unexpected table operation.", post2.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", post2.getOperation(), is(LOOKUP));
 
     verify(fifoMessagingService).sendMessageToFifoQueue(
         eq(POST_QUEUE_URL), eq(post3), any());
-    assertThat("Unexpected table operation.", post3.getOperation(), is(Operation.LOAD));
+    assertThat("Unexpected table operation.", post3.getOperation(), is(LOOKUP));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/PlacementSyncServiceTest.java
@@ -166,7 +166,7 @@ class PlacementSyncServiceTest {
     verify(eventPublisher).publishEvent(eventCaptor.capture());
 
     AfterSaveEvent<Placement> event = eventCaptor.getValue();
-    assertThat("Unexpected event placement.", event.getSource(), sameInstance(lookupPlacement));
+    assertThat("Unexpected event source.", event.getSource(), sameInstance(lookupPlacement));
     assertThat("Unexpected event collection.", event.getCollectionName(), is(ENTITY_NAME));
     assertThat("Unexpected event document.", event.getDocument(), nullValue());
 


### PR DESCRIPTION
When placement related data is deleted the placement data is retrieved from the database and queued to be processed.
If the queue already has a placement update or delete message then we will process the new details, before then processing the old details.

Change the operation type from `LOAD` to `LOOKUP` so we always grab the latest data available in the database. This will remove the ability for overwriting data with old data, but we will still get duplicate effort as we will process the placement twice. This should be considered acceptable until the sync process can be overhauled.

TIS21-6701