### PR TITLE
chore: local app config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.18.3"
+version = "1.18.4"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,54 @@
+application:
+  environment: local
+  aws:
+    sns:
+      delete-placement-event:
+        arn: ${local.sns-path}:tis-trainee-sync-delete-placement-event
+      delete-programme-membership-event:
+        arn: ${local.sns-path}:tis-trainee-sync-delete-programme-membership-event
+      update-conditions-of-joining:
+        arn: ${local.sns-path}:tis-trainee-sync-update-programme-membership-event
+        message-attribute: COJ_RECEIVED
+      update-contact-details:
+        arn: ${local.sns-path}:tis-trainee-sync-update-contact-details-event
+      update-gdc-details:
+        arn: ${local.sns-path}:tis-trainee-sync-update-gdc-details-event
+      update-gmc-details:
+        arn: ${local.sns-path}:tis-trainee-sync-update-gmc-details-event
+      update-person:
+        arn: ${local.sns-path}:tis-trainee-sync-update-person-event
+      update-person-owner:
+        arn: ${local.sns-path}:tis-trainee-sync-update-person-owner-event
+      update-personal-info:
+        arn: ${local.sns-path}:tis-trainee-sync-update-personal-info-event
+      update-placement-event:
+        arn: ${local.sns-path}:tis-trainee-sync-update-placement-event
+      update-programme-membership-event:
+        arn: ${local.sns-path}:tis-trainee-sync-update-programme-membership-event
+    sqs:
+      curriculum-membership: ${local.sqs-path}/tis-trainee-sync-local-curriculum-membership
+      placement: ${local.sqs-path}/tis-trainee-sync-local-placement
+      placement-specialty: ${local.sqs-path}/tis-trainee-sync-local-placement-specialty
+      post: ${local.sqs-path}/tis-trainee-sync-local-post
+      post-specialty: ${local.sqs-path}/tis-trainee-sync-local-post-specialty
+      profile-created: ${local.sqs-path}/tis-trainee-sync-local-profile-created
+      programme: ${local.sqs-path}/tis-trainee-sync-local-programme
+      programme-membership: ${local.sqs-path}/tis-trainee-sync-local-programme-membership
+      record: ${local.sqs-path}/tis-trainee-sync-local-record
+      request: ${local.sqs-path}/tis-trainee-sync-local-data-request
+
+local:
+  account-id: "000000000000"
+  sqs-path: ${spring.cloud.aws.endpoint}/${local.account-id}
+  sns-path: arn:aws:sns:${spring.cloud.aws.region.static}:${local.account-id}
+
+spring:
+  cloud:
+    aws:
+      credentials:
+        access-key: ${local.account-id}
+        secret-key: ${local.account-id}
+      endpoint: http://${LOCALSTACK_HOST:localhost}:4566
+      region:
+        static: eu-west-2
+


### PR DESCRIPTION
For new localstack setup, as per https://github.com/Health-Education-England/tis-trainee-forms/pull/671

I think this will leave the docker-compose env vars as something like:
```
    environment:
      - DB_HOST=host.docker.internal
      - LOCALSTACK_HOST=localstack
      - SPRING_PROFILES_ACTIVE=local
      - REFERENCE_HOST=tis-trainee-reference
      - TRAINEE_DETAILS_HOST=tis-trainee-details
      - REDIS_HOST=redis-cache
      - REDIS_USER=default
      - REDIS_PASSWORD=password
```
which could potentially be slimmed-down a bit further...
NO-TICKET