### PR TITLE
fix: sync RO-related data correctly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencyManagement {
   }
 }
 
+val mongockVersion = "5.4.2"
+
 dependencies {
   // Spring Boot starters
   implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
@@ -60,6 +62,9 @@ dependencies {
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sns")
 
   implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
+
+  implementation("io.mongock:mongock-springboot:${mongockVersion}")
+  implementation("io.mongock:mongodb-springdata-v4-driver:${mongockVersion}")
 
   val testContainersVersion = "1.19.8"
   testImplementation("org.springframework.cloud:spring-cloud-starter")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.18.4"
+version = "1.18.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/TisTraineeSyncApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/TisTraineeSyncApplication.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.tis.trainee.sync;
 
+import io.mongock.runner.springboot.EnableMongock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
@@ -31,6 +32,7 @@ import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @EnableCaching
+@EnableMongock
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class TisTraineeSyncApplication {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListener.java
@@ -45,8 +45,8 @@ import uk.nhs.hee.tis.trainee.sync.service.UserDesignatedBodySyncService;
 public class UserDesignatedBodyEventListener extends
     AbstractMongoEventListener<UserDesignatedBody> {
 
-  public static final String UDB_USER_NAME = "userName";
-  public static final String DESIGNATED_BODY_CODE = "designatedBodyCode";
+  public static final String USER_DB_USER_NAME = "userName";
+  public static final String USER_DB_DBC = "designatedBodyCode";
 
   private final UserDesignatedBodySyncService userDesignatedBodySyncService;
   private final DbcSyncService dbcSyncService;
@@ -117,8 +117,8 @@ public class UserDesignatedBodyEventListener extends
    */
   private void syncOrRequestMissingData(UserDesignatedBody userDesignatedBody,
       String eventContext) {
-    String userNameValue = userDesignatedBody.getData().get(UDB_USER_NAME);
-    String designatedBodyCodeValue = userDesignatedBody.getData().get(DESIGNATED_BODY_CODE);
+    String userNameValue = userDesignatedBody.getData().get(USER_DB_USER_NAME);
+    String designatedBodyCodeValue = userDesignatedBody.getData().get(USER_DB_DBC);
 
     Optional<HeeUser> optionalHeeUser = heeUserSyncService.findByName(userNameValue);
     Optional<Dbc> optionalDbc = dbcSyncService.findByDbc(designatedBodyCodeValue);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserRoleEventListener.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/event/UserRoleEventListener.java
@@ -43,8 +43,8 @@ import uk.nhs.hee.tis.trainee.sync.service.UserRoleSyncService;
 @Component
 public class UserRoleEventListener extends AbstractMongoEventListener<UserRole> {
 
-  public static final String USER_NAME = "userName";
-  public static final String ROLE_NAME = "roleName";
+  public static final String USER_ROLE_USER_NAME = "userName";
+  public static final String USER_ROLE_ROLE_NAME = "roleName";
   public static final String RESPONSIBLE_OFFICER_ROLE = "RVOfficer";
 
   private final UserRoleSyncService userRoleSyncService;
@@ -115,8 +115,8 @@ public class UserRoleEventListener extends AbstractMongoEventListener<UserRole> 
    * @param eventContext The event context (for logging purposes).
    */
   private void syncOrRequestMissingData(UserRole userRole, String eventContext) {
-    String userName = userRole.getData().get(USER_NAME);
-    String roleName = userRole.getData().get(ROLE_NAME);
+    String userName = userRole.getData().get(USER_ROLE_USER_NAME);
+    String roleName = userRole.getData().get(USER_ROLE_ROLE_NAME);
     if (roleName.equalsIgnoreCase(RESPONSIBLE_OFFICER_ROLE)) {
       Optional<HeeUser> optionalHeeUser = heeUserSyncService.findByName(userName);
       if (optionalHeeUser.isPresent()) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacade.java
@@ -24,7 +24,7 @@ package uk.nhs.hee.tis.trainee.sync.facade;
 import static uk.nhs.hee.tis.trainee.sync.event.DbcEventListener.DBC_DBC;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_ABBREVIATION;
 import static uk.nhs.hee.tis.trainee.sync.event.ProgrammeEventListener.PROGRAMME_OWNER;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.UDB_USER_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOAD;
 
 import java.util.ArrayList;
@@ -307,7 +307,7 @@ public class ProgrammeMembershipEnricherFacade {
           = userDesignatedBodyService.findByDbc(dbc.getData().get(DBC_DBC));
 
       for (UserDesignatedBody udb : udbSet) {
-        String username = udb.getData().get(UDB_USER_NAME);
+        String username = udb.getData().get(USER_DB_USER_NAME);
         Optional<UserRole> userRoleOptional = userRoleService.findRvOfficerRoleByUserName(username);
         if (userRoleOptional.isPresent()) {
           Optional<HeeUser> heeUserOptional = heeUserService.findByName(username);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTables.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTables.java
@@ -1,22 +1,22 @@
 /*
  * The MIT License (MIT)
  *
- *  Copyright 2024 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- *  associated documentation files (the "Software"), to deal in the Software without restriction,
- *  including without limitation the rights to use, copy, modify, merge, publish, distribute,
- *  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in all copies or
- *  substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- *  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- *  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package uk.nhs.hee.tis.trainee.sync.migration;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTables.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTables.java
@@ -1,0 +1,115 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright 2024 Crown Copyright (Health Education England)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ *  associated documentation files (the "Software"), to deal in the Software without restriction,
+ *  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ *  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all copies or
+ *  substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ *  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ *  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.migration;
+
+import com.mongodb.MongoException;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.CompoundIndexDefinition;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.hee.tis.trainee.sync.model.HeeUser;
+import uk.nhs.hee.tis.trainee.sync.model.UserDesignatedBody;
+import uk.nhs.hee.tis.trainee.sync.model.UserRole;
+
+/**
+ * Recreate ResponsibleOfficer-related collections.
+ */
+@Slf4j
+@ChangeUnit(id = "rebuildResponsibleOfficerTables", order = "1")
+public class RebuildResponsibleOfficerTables {
+
+  private static final String HEE_USER_COLLECTION = "heeUser";
+  private static final String USER_ROLE_COLLECTION = "userRole";
+  private static final String USER_DB_COLLECTION = "userDesignatedBody";
+
+  private final MongoTemplate mongoTemplate;
+
+  public RebuildResponsibleOfficerTables(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Recreate HeeUser, UserRole and UserDesignatedBody collections.
+   */
+  @Execution
+  public void migrate() {
+    try {
+      mongoTemplate.dropCollection(HEE_USER_COLLECTION);
+      log.info("Dropped {} collection.", HEE_USER_COLLECTION);
+      mongoTemplate.dropCollection(USER_ROLE_COLLECTION);
+      log.info("Dropped {} collection.", USER_ROLE_COLLECTION);
+      mongoTemplate.dropCollection(USER_DB_COLLECTION);
+      log.info("Dropped {} collection.", USER_DB_COLLECTION);
+
+      mongoTemplate.createCollection(HEE_USER_COLLECTION);
+      log.info("Recreated {} collection.", HEE_USER_COLLECTION);
+      mongoTemplate.createCollection(USER_ROLE_COLLECTION);
+      log.info("Recreated {} collection.", USER_ROLE_COLLECTION);
+      mongoTemplate.createCollection(USER_DB_COLLECTION);
+      log.info("Recreated {} collection.", USER_DB_COLLECTION);
+
+      // HeeUser
+      IndexOperations heeUserIndexOps = mongoTemplate.indexOps(HeeUser.class);
+      heeUserIndexOps.ensureIndex(new Index().on("data.name", Direction.ASC));
+
+      // UserDesignatedBody
+      IndexOperations userDbIndexOps = mongoTemplate.indexOps(UserDesignatedBody.class);
+      userDbIndexOps.ensureIndex(new Index().on("data.userName", Direction.ASC));
+      userDbIndexOps.ensureIndex(new Index().on("data.designatedBodyCode", Direction.ASC));
+      Document udbKeys = new Document();
+      udbKeys.put("data.userName", 1);
+      udbKeys.put("data.designatedBodyCode", 1);
+      Index udbCompoundIndex = new CompoundIndexDefinition(udbKeys).unique()
+          .named("userDesignatedBodyCompoundIndex");
+      userDbIndexOps.ensureIndex(udbCompoundIndex);
+
+      // UserRole
+      IndexOperations userRoleIndexOps = mongoTemplate.indexOps(UserRole.class);
+      userRoleIndexOps.ensureIndex(new Index().on("data.userName", Direction.ASC));
+      userRoleIndexOps.ensureIndex(new Index().on("data.roleName", Direction.ASC));
+      Document urKeys = new Document();
+      urKeys.put("data.userName", 1);
+      urKeys.put("data.roleName", 1);
+      Index urCompoundIndex = new CompoundIndexDefinition(urKeys).unique()
+          .named("userRoleCompoundIndex");
+      userRoleIndexOps.ensureIndex(urCompoundIndex);
+
+    } catch (MongoException me) {
+      log.error("Unable to recreate collections due to an error: {} ", me.toString());
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available "
+        + "for 'rebuildResponsibleOfficerTables' migration.");
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
@@ -42,6 +42,7 @@ public interface UserRoleRepository extends MongoRepository<UserRole, String> {
   @Override
   Optional<UserRole> findById(String id);
 
+  //TODO check if save creates duplicates
   @CachePut(key = "#entity.tisId")
   @Override
   <T extends UserRole> T save(T entity);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
@@ -42,7 +42,6 @@ public interface UserRoleRepository extends MongoRepository<UserRole, String> {
   @Override
   Optional<UserRole> findById(String id);
 
-  //TODO check if save creates duplicates
   @CachePut(key = "#entity.tisId")
   @Override
   <T extends UserRole> T save(T entity);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/repository/UserRoleRepository.java
@@ -50,6 +50,9 @@ public interface UserRoleRepository extends MongoRepository<UserRole, String> {
   @Override
   void deleteById(String id);
 
+  @Query("{ $and: [ {'data.userName' : ?0}, {'data.roleName' : ?1} ]}")
+  Optional<UserRole> findByUserNameAndRoleName(String userName, String roleName);
+
   @Query("{ $and: [ {'data.userName' : ?0}, {'data.roleName' : \"RVOfficer\"} ]}")
   Optional<UserRole> findRvOfficerRoleByUserName(String userName);
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncService.java
@@ -22,7 +22,7 @@
 package uk.nhs.hee.tis.trainee.sync.service;
 
 import static uk.nhs.hee.tis.trainee.sync.event.DbcEventListener.DBC_NAME;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.DESIGNATED_BODY_CODE;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
 import static uk.nhs.hee.tis.trainee.sync.model.Dbc.ENTITY_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOOKUP;
@@ -93,7 +93,7 @@ public class DbcSyncService implements SyncService {
         AfterSaveEvent<Dbc> event = new AfterSaveEvent<>(optionalDbc.get(), null, ENTITY_NAME);
         eventPublisher.publishEvent(event);
       } else {
-        requestByDbc(dbc.getData().get(DESIGNATED_BODY_CODE));
+        requestByDbc(dbc.getData().get(USER_DB_DBC));
         requested = true;
       }
     } else {
@@ -213,7 +213,7 @@ public class DbcSyncService implements SyncService {
    * @param udb The user designated body to filter programmes by.
    */
   private void syncDesignatedBodyRelatedProgrammes(UserDesignatedBody udb) {
-    String dbCode = udb.getData().get(DESIGNATED_BODY_CODE);
+    String dbCode = udb.getData().get(USER_DB_DBC);
     log.debug("User designated body {} found, searching for DBC record.", dbCode);
     Optional<Dbc> optionalDbc = findByDbc(dbCode);
     if (optionalDbc.isPresent()) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncService.java
@@ -61,7 +61,9 @@ public class HeeUserSyncService implements SyncService {
     }
 
     if (heeUser.getOperation().equals(DELETE)) {
-      repository.deleteById(heeUser.getTisId());
+      String name = heeUser.getData().get("name");
+      Optional<HeeUser> heeUserOptional = findByName(name);
+      heeUserOptional.ifPresent(user -> repository.deleteById(user.getTisId()));
     } else {
       repository.save((HeeUser) heeUser);
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncService.java
@@ -60,15 +60,19 @@ public class HeeUserSyncService implements SyncService {
       throw new IllegalArgumentException(message);
     }
 
-    if (heeUser.getOperation().equals(DELETE)) {
-      String name = heeUser.getData().get("name");
-      Optional<HeeUser> heeUserOptional = findByName(name);
-      heeUserOptional.ifPresent(user -> repository.deleteById(user.getTisId()));
-    } else {
+    String name = heeUser.getData().get(HEE_USER_NAME);
+    Optional<HeeUser> heeUserOptional = findByName(name);
+    heeUserOptional.ifPresent(user -> {
+      repository.deleteById(user.getTisId());
+      log.info("Deleted HEE user {}.", user);
+    });
+
+    if (!heeUser.getOperation().equals(DELETE)) {
       repository.save((HeeUser) heeUser);
+      log.info("Saved HEE user {}.", heeUser);
     }
 
-    requestCacheService.deleteItemFromCache(HeeUser.ENTITY_NAME, heeUser.getTisId());
+    requestCacheService.deleteItemFromCache(HeeUser.ENTITY_NAME, name);
   }
 
   public Optional<HeeUser> findById(String id) {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncService.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.tis.trainee.sync.service;
 
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
+import io.sentry.protocol.User;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,11 @@ public class UserDesignatedBodySyncService implements SyncService {
     }
 
     if (userDesignatedBody.getOperation().equals(DELETE)) {
-      repository.deleteById(userDesignatedBody.getTisId());
+      String userName = userDesignatedBody.getData().get("userName");
+      String designatedBodyCode = userDesignatedBody.getData().get("designatedBodyCode");
+      Optional<UserDesignatedBody> udbOptional =
+          repository.findByUserNameAndDesignatedBodyCode(userName, designatedBodyCode);
+      udbOptional.ifPresent(designatedBody -> repository.deleteById(designatedBody.getTisId()));
     } else {
       repository.save((UserDesignatedBody) userDesignatedBody);
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncService.java
@@ -23,7 +23,6 @@ package uk.nhs.hee.tis.trainee.sync.service;
 
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
-import io.sentry.protocol.User;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
+import uk.nhs.hee.tis.trainee.sync.model.UserDesignatedBody;
 import uk.nhs.hee.tis.trainee.sync.model.UserRole;
 import uk.nhs.hee.tis.trainee.sync.repository.UserRoleRepository;
 
@@ -54,7 +55,11 @@ public class UserRoleSyncService implements SyncService {
     }
 
     if (userRole.getOperation().equals(DELETE)) {
-      repository.deleteById(userRole.getTisId());
+      String userName = userRole.getData().get("userName");
+      String roleName = userRole.getData().get("roleName");
+      Optional<UserRole> userRoleOptional =
+          repository.findByUserNameAndRoleName(userName, roleName);
+      userRoleOptional.ifPresent(ur -> repository.deleteById(ur.getTisId()));
     } else {
       repository.save((UserRole) userRole);
     }

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
-import uk.nhs.hee.tis.trainee.sync.model.UserDesignatedBody;
 import uk.nhs.hee.tis.trainee.sync.model.UserRole;
 import uk.nhs.hee.tis.trainee.sync.repository.UserRoleRepository;
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncService.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import java.util.Optional;
@@ -37,9 +39,6 @@ import uk.nhs.hee.tis.trainee.sync.repository.UserRoleRepository;
 @Service("auth-UserRole")
 public class UserRoleSyncService implements SyncService {
 
-  public static final String USER_ROLE_USERNAME = "userName";
-  public static final String USER_ROLE_ROLE = "roleName";
-
   private final UserRoleRepository repository;
 
   UserRoleSyncService(UserRoleRepository repository) {
@@ -53,14 +52,17 @@ public class UserRoleSyncService implements SyncService {
       throw new IllegalArgumentException(message);
     }
 
+    String userName = userRole.getData().get(USER_ROLE_USER_NAME);
+    String roleName = userRole.getData().get(USER_ROLE_ROLE_NAME);
+    Optional<UserRole> userRoleOptional =
+        repository.findByUserNameAndRoleName(userName, roleName);
+
     if (userRole.getOperation().equals(DELETE)) {
-      String userName = userRole.getData().get("userName");
-      String roleName = userRole.getData().get("roleName");
-      Optional<UserRole> userRoleOptional =
-          repository.findByUserNameAndRoleName(userName, roleName);
       userRoleOptional.ifPresent(ur -> repository.deleteById(ur.getTisId()));
     } else {
-      repository.save((UserRole) userRole);
+      userRoleOptional.ifPresentOrElse(
+          ur -> log.info("User role record {} already exists.", ur),
+          () -> repository.save((UserRole) userRole));
     }
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
@@ -59,6 +59,7 @@ import uk.nhs.hee.tis.trainee.sync.service.ReferenceSyncService;
 class CachingHeeUserIntTest {
 
   private static final String HEEUSER_FORDY = "fordy";
+  private static final String USERNAME = "theUser";
 
   // We require access to the mock before the proxy wraps it.
   private static HeeUserRepository mockHeeUserRepository;
@@ -85,7 +86,7 @@ class CachingHeeUserIntTest {
     heeUser.setTisId(HEEUSER_FORDY);
     heeUser.setOperation(Operation.DELETE);
     heeUser.setTable(HeeUser.ENTITY_NAME);
-    heeUser.setData(Map.of("name", HEEUSER_FORDY));
+    heeUser.setData(Map.of("name", USERNAME));
 
     dbcCache = cacheManager.getCache(HeeUser.ENTITY_NAME);
   }
@@ -117,7 +118,12 @@ class CachingHeeUserIntTest {
     heeUserSyncService.findById(HEEUSER_FORDY);
     assertThat(dbcCache.get(HEEUSER_FORDY)).isNotNull();
 
-    when(mockHeeUserRepository.findByName(HEEUSER_FORDY)).thenReturn(Optional.of(heeUser));
+    when(mockHeeUserRepository.findByName(USERNAME)).thenReturn(Optional.of(heeUser));
+
+    HeeUser heeUserFromTis = new HeeUser(); //arrives without ID
+    heeUserFromTis.setOperation(Operation.DELETE);
+    heeUserFromTis.setTable(HeeUser.ENTITY_NAME);
+    heeUserFromTis.setData(Map.of("name", USERNAME));
     heeUserSyncService.syncRecord(heeUser);
 
     assertThat(dbcCache.get(HEEUSER_FORDY)).isNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,7 @@ class CachingHeeUserIntTest {
     heeUser.setTisId(HEEUSER_FORDY);
     heeUser.setOperation(Operation.DELETE);
     heeUser.setTable(HeeUser.ENTITY_NAME);
+    heeUser.setData(Map.of("name", HEEUSER_FORDY));
 
     dbcCache = cacheManager.getCache(HeeUser.ENTITY_NAME);
   }
@@ -115,7 +117,9 @@ class CachingHeeUserIntTest {
     heeUserSyncService.findById(HEEUSER_FORDY);
     assertThat(dbcCache.get(HEEUSER_FORDY)).isNotNull();
 
+    when(mockHeeUserRepository.findByName(HEEUSER_FORDY)).thenReturn(Optional.of(heeUser));
     heeUserSyncService.syncRecord(heeUser);
+
     assertThat(dbcCache.get(HEEUSER_FORDY)).isNull();
     assertThat(dbcCache.get(otherKey)).isNotNull();
     verify(mockHeeUserRepository).deleteById(HEEUSER_FORDY);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static uk.nhs.hee.tis.trainee.sync.event.HeeUserEventListener.HEE_USER_NAME;
 
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
@@ -123,8 +124,8 @@ class CachingHeeUserIntTest {
     HeeUser heeUserFromTis = new HeeUser(); //arrives without ID
     heeUserFromTis.setOperation(Operation.DELETE);
     heeUserFromTis.setTable(HeeUser.ENTITY_NAME);
-    heeUserFromTis.setData(Map.of("name", USERNAME));
-    heeUserSyncService.syncRecord(heeUser);
+    heeUserFromTis.setData(Map.of(HEE_USER_NAME, USERNAME));
+    heeUserSyncService.syncRecord(heeUserFromTis);
 
     assertThat(dbcCache.get(HEEUSER_FORDY)).isNull();
     assertThat(dbcCache.get(otherKey)).isNotNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingHeeUserIntTest.java
@@ -87,7 +87,7 @@ class CachingHeeUserIntTest {
     heeUser.setTisId(HEEUSER_FORDY);
     heeUser.setOperation(Operation.DELETE);
     heeUser.setTable(HeeUser.ENTITY_NAME);
-    heeUser.setData(Map.of("name", USERNAME));
+    heeUser.setData(Map.of(HEE_USER_NAME, USERNAME));
 
     dbcCache = cacheManager.getCache(HeeUser.ENTITY_NAME);
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
@@ -124,6 +124,11 @@ class CachingUserDesignatedBodyIntTest {
 
     when(mockUserDesignatedBodyRepository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
         .thenReturn(Optional.of(userDesignatedBody));
+
+    UserDesignatedBody userDesignatedBodyFromTis = new UserDesignatedBody(); //arrives without ID
+    userDesignatedBodyFromTis.setOperation(Operation.DELETE);
+    userDesignatedBodyFromTis.setTable(UserDesignatedBody.ENTITY_NAME);
+    userDesignatedBodyFromTis.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
     userDbSyncService.syncRecord(userDesignatedBody);
 
     assertThat(dbcCache.get(USER_DESIGNATED_BODY_FORDY)).isNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
@@ -89,7 +89,7 @@ class CachingUserDesignatedBodyIntTest {
     userDesignatedBody.setTisId(USER_DESIGNATED_BODY_FORDY);
     userDesignatedBody.setOperation(Operation.DELETE);
     userDesignatedBody.setTable(UserDesignatedBody.ENTITY_NAME);
-    userDesignatedBody.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
+    userDesignatedBody.setData(Map.of(USER_DB_USER_NAME, USERNAME, USER_DB_DBC, DBC));
 
     dbcCache = cacheManager.getCache(UserDesignatedBody.ENTITY_NAME);
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserDesignatedBodyIntTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_USER_NAME;
 
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
@@ -128,8 +130,8 @@ class CachingUserDesignatedBodyIntTest {
     UserDesignatedBody userDesignatedBodyFromTis = new UserDesignatedBody(); //arrives without ID
     userDesignatedBodyFromTis.setOperation(Operation.DELETE);
     userDesignatedBodyFromTis.setTable(UserDesignatedBody.ENTITY_NAME);
-    userDesignatedBodyFromTis.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
-    userDbSyncService.syncRecord(userDesignatedBody);
+    userDesignatedBodyFromTis.setData(Map.of(USER_DB_USER_NAME, USERNAME, USER_DB_DBC, DBC));
+    userDbSyncService.syncRecord(userDesignatedBodyFromTis);
 
     assertThat(dbcCache.get(USER_DESIGNATED_BODY_FORDY)).isNull();
     assertThat(dbcCache.get(otherKey)).isNotNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
@@ -125,8 +127,8 @@ class CachingUserRoleIntTest {
     UserRole userRoleFromTis = new UserRole(); //arrives without ID
     userRoleFromTis.setOperation(Operation.DELETE);
     userRoleFromTis.setTable(UserRole.ENTITY_NAME);
-    userRoleFromTis.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
-    userRoleSyncService.syncRecord(userRole);
+    userRoleFromTis.setData(Map.of(USER_ROLE_USER_NAME, USERNAME, USER_ROLE_ROLE_NAME, ROLENAME));
+    userRoleSyncService.syncRecord(userRoleFromTis);
 
     assertThat(dbcCache.get(USER_ROLE_FORDY)).isNull();
     assertThat(dbcCache.get(otherKey)).isNotNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
@@ -121,6 +121,11 @@ class CachingUserRoleIntTest {
 
     when(mockUserRoleRepository.findByUserNameAndRoleName(USERNAME, ROLENAME))
         .thenReturn(Optional.of(userRole));
+
+    UserRole userRoleFromTis = new UserRole(); //arrives without ID
+    userRoleFromTis.setOperation(Operation.DELETE);
+    userRoleFromTis.setTable(UserRole.ENTITY_NAME);
+    userRoleFromTis.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
     userRoleSyncService.syncRecord(userRole);
 
     assertThat(dbcCache.get(USER_ROLE_FORDY)).isNull();

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
@@ -89,7 +89,7 @@ class CachingUserRoleIntTest {
     userRole.setTisId(USER_ROLE_FORDY);
     userRole.setOperation(Operation.DELETE);
     userRole.setTable(UserRole.ENTITY_NAME);
-    userRole.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
+    userRole.setData(Map.of(USER_ROLE_USER_NAME, USERNAME, USER_ROLE_ROLE_NAME, ROLENAME));
 
     dbcCache = cacheManager.getCache(UserRole.ENTITY_NAME);
   }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingUserRoleIntTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER
 
 import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,8 @@ import uk.nhs.hee.tis.trainee.sync.service.UserRoleSyncService;
 class CachingUserRoleIntTest {
 
   private static final String USER_ROLE_FORDY = "fordy";
+  private static final String USERNAME = "theUser";
+  private static final String ROLENAME = "theRole";
 
   // We require access to the mock before the proxy wraps it.
   private static UserRoleRepository mockUserRoleRepository;
@@ -84,6 +87,7 @@ class CachingUserRoleIntTest {
     userRole.setTisId(USER_ROLE_FORDY);
     userRole.setOperation(Operation.DELETE);
     userRole.setTable(UserRole.ENTITY_NAME);
+    userRole.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
 
     dbcCache = cacheManager.getCache(UserRole.ENTITY_NAME);
   }
@@ -115,7 +119,10 @@ class CachingUserRoleIntTest {
     userRoleSyncService.findById(USER_ROLE_FORDY);
     assertThat(dbcCache.get(USER_ROLE_FORDY)).isNotNull();
 
+    when(mockUserRoleRepository.findByUserNameAndRoleName(USERNAME, ROLENAME))
+        .thenReturn(Optional.of(userRole));
     userRoleSyncService.syncRecord(userRole);
+
     assertThat(dbcCache.get(USER_ROLE_FORDY)).isNull();
     assertThat(dbcCache.get(otherKey)).isNotNull();
     verify(mockUserRoleRepository).deleteById(USER_ROLE_FORDY);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserDesignatedBodyEventListenerTest.java
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.DESIGNATED_BODY_CODE;
-import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 
 import java.util.Optional;
 import org.bson.Document;
@@ -76,8 +76,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldResyncRelatedDbcsAfterSaveIfHeeUserAndDbcPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserDesignatedBody> event = new AfterSaveEvent<>(userDesignatedBody, null, null);
 
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));
@@ -97,8 +97,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldRequestRelatedHeeUserAfterSaveIfHeeUserNotPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserDesignatedBody> event = new AfterSaveEvent<>(userDesignatedBody, null, null);
 
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.empty());
@@ -115,8 +115,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldRequestRelatedDbcAfterSaveIfDbcNotPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserDesignatedBody> event = new AfterSaveEvent<>(userDesignatedBody, null, null);
 
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));
@@ -166,8 +166,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldResyncRelatedDbcsAfterDeleteIfHeeUserAndDbcPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_DB_ID, UserDesignatedBody.class)).thenReturn(userDesignatedBody);
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));
@@ -191,8 +191,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldRequestRelatedHeeUserAfterDeleteIfHeeUserNotPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_DB_ID, UserDesignatedBody.class)).thenReturn(userDesignatedBody);
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.empty());
@@ -213,8 +213,8 @@ class UserDesignatedBodyEventListenerTest {
   void shouldRequestRelatedDbcAfterDeleteIfDbcNotPresent() {
     UserDesignatedBody userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(USER_DB_ID);
-    userDesignatedBody.getData().put(DESIGNATED_BODY_CODE, DESIGNATED_BODY_CODE_VALUE);
-    userDesignatedBody.getData().put(USER_NAME, USER_NAME_VALUE);
+    userDesignatedBody.getData().put(USER_DB_DBC, DESIGNATED_BODY_CODE_VALUE);
+    userDesignatedBody.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_DB_ID, UserDesignatedBody.class)).thenReturn(userDesignatedBody);
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserRoleEventListenerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/event/UserRoleEventListenerTest.java
@@ -27,8 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.RESPONSIBLE_OFFICER_ROLE;
-import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.ROLE_NAME;
-import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 
 import java.util.Optional;
 import org.bson.Document;
@@ -71,8 +71,8 @@ class UserRoleEventListenerTest {
   void shouldNotResyncRelatedDbcsAfterSaveWhenNotRoRole() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, "some other role");
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "some other role");
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserRole> event = new AfterSaveEvent<>(userRole, null, null);
 
     listener.onAfterSave(event);
@@ -85,8 +85,8 @@ class UserRoleEventListenerTest {
   void shouldResyncRelatedDbcsAfterSaveWhenRoRoleAndHeeUserPresent() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserRole> event = new AfterSaveEvent<>(userRole, null, null);
 
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));
@@ -101,8 +101,8 @@ class UserRoleEventListenerTest {
   void shouldRequestRelatedHeeUserAfterSaveWhenRoRoleAndHeeUserNotPresent() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
     AfterSaveEvent<UserRole> event = new AfterSaveEvent<>(userRole, null, null);
 
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.empty());
@@ -150,8 +150,8 @@ class UserRoleEventListenerTest {
   void shouldNotResyncRelatedDbcsAfterDeleteWhenNotRoRole() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, "some other role");
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "some other role");
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_ROLE_ID, UserRole.class)).thenReturn(userRole);
 
@@ -169,8 +169,8 @@ class UserRoleEventListenerTest {
   void shouldResyncRelatedDbcsAfterDeleteWhenRoRoleAndHeeUserPresent() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_ROLE_ID, UserRole.class)).thenReturn(userRole);
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.of(new HeeUser()));
@@ -189,8 +189,8 @@ class UserRoleEventListenerTest {
   void shouldRequestRelatedHeeUserAfterDeleteWhenRoRoleAndHeeUserNotPresent() {
     UserRole userRole = new UserRole();
     userRole.setTisId(USER_ROLE_ID);
-    userRole.getData().put(ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
-    userRole.getData().put(USER_NAME, USER_NAME_VALUE);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, RESPONSIBLE_OFFICER_ROLE);
+    userRole.getData().put(USER_ROLE_USER_NAME, USER_NAME_VALUE);
 
     when(cache.get(USER_ROLE_ID, UserRole.class)).thenReturn(userRole);
     when(heeUserService.findByName(USER_NAME_VALUE)).thenReturn(Optional.empty());

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -41,10 +41,10 @@ import static uk.nhs.hee.tis.trainee.sync.event.HeeUserEventListener.HEE_USER_NA
 import static uk.nhs.hee.tis.trainee.sync.event.HeeUserEventListener.HEE_USER_PHONE;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_ABBREVIATION;
 import static uk.nhs.hee.tis.trainee.sync.event.LocalOfficeEventListener.LOCAL_OFFICE_NAME;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.DESIGNATED_BODY_CODE;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.UDB_USER_NAME;
-import static uk.nhs.hee.tis.trainee.sync.service.UserRoleSyncService.USER_ROLE_ROLE;
-import static uk.nhs.hee.tis.trainee.sync.service.UserRoleSyncService.USER_ROLE_USERNAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_USER_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -400,13 +400,13 @@ class ProgrammeMembershipEnricherFacadeTest {
     Mockito.reset(userRoleService);
     UserRole userRole = new UserRole();
     userRole.setData(Map.of(
-        USER_ROLE_USERNAME, USER_NAME_VALUE,
-        USER_ROLE_ROLE, ROLE_VALUE
+        USER_ROLE_USER_NAME, USER_NAME_VALUE,
+        USER_ROLE_ROLE_NAME, ROLE_VALUE
     ));
     UserRole userRole2 = new UserRole();
     userRole.setData(Map.of(
-        USER_ROLE_USERNAME, "some other user",
-        USER_ROLE_ROLE, ROLE_VALUE
+        USER_ROLE_USER_NAME, "some other user",
+        USER_ROLE_ROLE_NAME, ROLE_VALUE
     ));
     when(userRoleService.findRvOfficerRoleByUserName(anyString()))
         .thenReturn(Optional.of(userRole), Optional.of(userRole2));
@@ -885,15 +885,15 @@ class ProgrammeMembershipEnricherFacadeTest {
 
     UserDesignatedBody udb = new UserDesignatedBody();
     udb.setData(Map.of(
-        UDB_USER_NAME, USER_NAME_VALUE,
-        DESIGNATED_BODY_CODE, DBC_DBC_VALUE
+        USER_DB_USER_NAME, USER_NAME_VALUE,
+        USER_DB_DBC, DBC_DBC_VALUE
     ));
     when(udbService.findByDbc(DBC_DBC_VALUE)).thenReturn(Set.of(udb));
 
     UserRole userRole = new UserRole();
     userRole.setData(Map.of(
-        USER_ROLE_USERNAME, USER_NAME_VALUE,
-        USER_ROLE_ROLE, ROLE_VALUE
+        USER_ROLE_USER_NAME, USER_NAME_VALUE,
+        USER_ROLE_ROLE_NAME, ROLE_VALUE
     ));
     when(userRoleService.findRvOfficerRoleByUserName(USER_NAME_VALUE)).thenReturn(
         Optional.of(userRole));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTablesTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTablesTest.java
@@ -1,22 +1,22 @@
 /*
  * The MIT License (MIT)
  *
- *  Copyright 2024 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
- *  associated documentation files (the "Software"), to deal in the Software without restriction,
- *  including without limitation the rights to use, copy, modify, merge, publish, distribute,
- *  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
  *
- *  The above copyright notice and this permission notice shall be included in all copies or
- *  substantial portions of the Software.
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- *  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- *  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 package uk.nhs.hee.tis.trainee.sync.migration;

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTablesTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/migration/RebuildResponsibleOfficerTablesTest.java
@@ -1,0 +1,157 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright 2024 Crown Copyright (Health Education England)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ *  associated documentation files (the "Software"), to deal in the Software without restriction,
+ *  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ *  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all copies or
+ *  substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ *  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ *  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.trainee.sync.migration;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoException;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.hee.tis.trainee.sync.model.HeeUser;
+import uk.nhs.hee.tis.trainee.sync.model.UserDesignatedBody;
+import uk.nhs.hee.tis.trainee.sync.model.UserRole;
+
+class RebuildResponsibleOfficerTablesTest {
+  private static final String HEE_USER_COLLECTION = "heeUser";
+  private static final String USER_ROLE_COLLECTION = "userRole";
+  private static final String USER_DB_COLLECTION = "userDesignatedBody";
+
+  private RebuildResponsibleOfficerTables migration;
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    migration = new RebuildResponsibleOfficerTables(template);
+  }
+
+  @Test
+  void shouldRecreateResponsibleOfficerTables() {
+    IndexOperations heeUserIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(HeeUser.class)).thenReturn(heeUserIndexOperationMock);
+    IndexOperations userRoleIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(UserRole.class)).thenReturn(userRoleIndexOperationMock);
+    IndexOperations userDbIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(UserDesignatedBody.class)).thenReturn(userDbIndexOperationMock);
+
+    migration.migrate();
+
+    verify(template).dropCollection(HEE_USER_COLLECTION);
+    verify(template).dropCollection(USER_ROLE_COLLECTION);
+    verify(template).dropCollection(USER_DB_COLLECTION);
+
+    verify(template).createCollection(HEE_USER_COLLECTION);
+    verify(template).createCollection(USER_ROLE_COLLECTION);
+    verify(template).createCollection(USER_DB_COLLECTION);
+  }
+
+  @Test
+  void shouldSetIndexesInResponsibleOfficerTables() {
+    IndexOperations heeUserIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(HeeUser.class)).thenReturn(heeUserIndexOperationMock);
+    IndexOperations userRoleIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(UserRole.class)).thenReturn(userRoleIndexOperationMock);
+    IndexOperations userDbIndexOperationMock = mock(IndexOperations.class);
+    when(template.indexOps(UserDesignatedBody.class)).thenReturn(userDbIndexOperationMock);
+
+    migration.migrate();
+
+    ArgumentCaptor<IndexDefinition> heeUserIndexCaptor
+        = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(heeUserIndexOperationMock, atLeastOnce()).ensureIndex(heeUserIndexCaptor.capture());
+
+    List<IndexDefinition> heeUserIndexes = heeUserIndexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", heeUserIndexes.size(), is(1));
+
+    List<String> heeUserIndexKeys = heeUserIndexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected index.", heeUserIndexKeys, hasItems("data.name"));
+
+
+    ArgumentCaptor<IndexDefinition> userDbIndexCaptor
+        = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(userDbIndexOperationMock, atLeastOnce()).ensureIndex(userDbIndexCaptor.capture());
+
+    List<IndexDefinition> userDbIndexes = userDbIndexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", userDbIndexes.size(), is(3));
+
+    List<String> userDbIndexKeys = userDbIndexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected index.", userDbIndexKeys,
+        hasItems("data.userName", "data.designatedBodyCode"));
+    List<String> userDbIndexCompositeKeys = userDbIndexes.stream()
+        .filter(i -> i.getIndexKeys().size() > 1)
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected compound index.", userDbIndexCompositeKeys,
+        hasItems("data.userName", "data.designatedBodyCode"));
+
+
+    ArgumentCaptor<IndexDefinition> userRoleIndexCaptor
+        = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(userRoleIndexOperationMock, atLeastOnce()).ensureIndex(userRoleIndexCaptor.capture());
+
+    List<IndexDefinition> userRoleIndexes = userRoleIndexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", userRoleIndexes.size(), is(3));
+
+    List<String> userRoleIndexKeys = userRoleIndexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected index.", userRoleIndexKeys,
+        hasItems("data.userName", "data.roleName"));
+    List<String> userRoleIndexCompositeKeys = userRoleIndexes.stream()
+        .filter(i -> i.getIndexKeys().size() > 1)
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .toList();
+    assertThat("Unexpected compound index.", userRoleIndexCompositeKeys,
+        hasItems("data.userName", "data.roleName"));
+  }
+
+  @Test
+  void shouldCatchMongoExceptionNotThrowIt() {
+    doThrow(new MongoException("exception")).when(template).dropCollection(anyString());
+    Assertions.assertDoesNotThrow(() -> migration.migrate());
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(template);
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/DbcSyncServiceTest.java
@@ -42,9 +42,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.event.DbcEventListener.DBC_NAME;
-import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.DESIGNATED_BODY_CODE;
-import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.ROLE_NAME;
-import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Dbc.ENTITY_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOAD;
@@ -349,16 +349,16 @@ class DbcSyncServiceTest {
   @Test
   void shouldPublishDbcSaveEventsWhenResyncResponsibleOfficerUser() {
     UserRole userRole = new UserRole();
-    userRole.getData().put(USER_NAME, USERNAME);
-    userRole.getData().put(ROLE_NAME, "RVOfficer");
+    userRole.getData().put(USER_ROLE_USER_NAME, USERNAME);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "RVOfficer");
 
     when(userRoleSyncService.findRvOfficerRoleByUserName(USERNAME)).thenReturn(
         Optional.of(userRole));
 
     UserDesignatedBody udb1 = new UserDesignatedBody();
-    udb1.getData().put(DESIGNATED_BODY_CODE, DBCODE1);
+    udb1.getData().put(USER_DB_DBC, DBCODE1);
     UserDesignatedBody udb2 = new UserDesignatedBody();
-    udb2.getData().put(DESIGNATED_BODY_CODE, DBCODE2);
+    udb2.getData().put(USER_DB_DBC, DBCODE2);
 
     when(udbSyncService.findByUserName(USERNAME)).thenReturn(Set.of(udb1, udb2));
 
@@ -398,14 +398,14 @@ class DbcSyncServiceTest {
   @Test
   void shouldNotPublishDbcSaveEventsWhenDbcNotFound() {
     UserRole userRole = new UserRole();
-    userRole.getData().put(USER_NAME, USERNAME);
-    userRole.getData().put(ROLE_NAME, "RVOfficer");
+    userRole.getData().put(USER_ROLE_USER_NAME, USERNAME);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "RVOfficer");
 
     when(userRoleSyncService.findRvOfficerRoleByUserName(USERNAME)).thenReturn(
         Optional.of(userRole));
 
     UserDesignatedBody udb1 = new UserDesignatedBody();
-    udb1.getData().put(DESIGNATED_BODY_CODE, DBCODE1);
+    udb1.getData().put(USER_DB_DBC, DBCODE1);
 
     when(udbSyncService.findByUserName(USERNAME)).thenReturn(Set.of(udb1));
 
@@ -436,14 +436,14 @@ class DbcSyncServiceTest {
   @Test
   void shouldPublishDbcSaveEventWhenResyncResponsibleOfficerUserSingleDbc() {
     UserRole userRole = new UserRole();
-    userRole.getData().put(USER_NAME, USERNAME);
-    userRole.getData().put(ROLE_NAME, "RVOfficer");
+    userRole.getData().put(USER_ROLE_USER_NAME, USERNAME);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "RVOfficer");
 
     when(userRoleSyncService.findRvOfficerRoleByUserName(USERNAME)).thenReturn(
         Optional.of(userRole));
 
     UserDesignatedBody udb1 = new UserDesignatedBody();
-    udb1.getData().put(DESIGNATED_BODY_CODE, DBCODE1);
+    udb1.getData().put(USER_DB_DBC, DBCODE1);
 
     when(udbSyncService.findByUserNameAndDesignatedBodyCode(USERNAME, DBCODE1))
         .thenReturn(Optional.of(udb1));
@@ -469,8 +469,8 @@ class DbcSyncServiceTest {
   @Test
   void shouldNotPublishDbcSaveEventWhenSingleDbcNotFound() {
     UserRole userRole = new UserRole();
-    userRole.getData().put(USER_NAME, USERNAME);
-    userRole.getData().put(ROLE_NAME, "RVOfficer");
+    userRole.getData().put(USER_ROLE_USER_NAME, USERNAME);
+    userRole.getData().put(USER_ROLE_ROLE_NAME, "RVOfficer");
 
     when(userRoleSyncService.findRvOfficerRoleByUserName(USERNAME)).thenReturn(
         Optional.of(userRole));

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
@@ -55,8 +55,11 @@ import uk.nhs.hee.tis.trainee.sync.repository.HeeUserRepository;
 
 class HeeUserSyncServiceTest {
 
+  private static final String ID = "theId";
   private static final String NAME = "HeeUser";
   private static final String NAME_2 = "HeeUser2";
+  private static final String EMAIL = "email@email.com";
+  private static final String EMAIL_2 = "email2@email.com";
 
   private HeeUserSyncService service;
   private HeeUserRepository repository;
@@ -66,6 +69,7 @@ class HeeUserSyncServiceTest {
   private RequestCacheService requestCacheService;
 
   private HeeUser heeUser;
+  private HeeUser heeUserFromTis;
 
   private Map<String, String> whereMap;
 
@@ -80,8 +84,10 @@ class HeeUserSyncServiceTest {
     service = new HeeUserSyncService(repository, dataRequestService, requestCacheService);
 
     heeUser = new HeeUser();
-    heeUser.setTisId(NAME);
-    heeUser.setData(Map.of("name", NAME));
+    heeUser.setTisId(ID);
+    heeUser.setData(Map.of("name", NAME, "emailAddress", EMAIL));
+    heeUserFromTis = new HeeUser(); //arrives without ID
+    heeUserFromTis.setData(Map.of("name", NAME, "emailAddress", EMAIL_2));
 
     whereMap = Map.of("name", NAME);
     whereMap2 = Map.of("name", NAME_2);
@@ -95,12 +101,28 @@ class HeeUserSyncServiceTest {
 
   @ParameterizedTest(name = "Should store records when operation is {0}.")
   @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
-  void shouldStoreRecords(Operation operation) {
-    heeUser.setOperation(operation);
+  void shouldReplaceRecordsIfExists(Operation operation) {
+    when(repository.findByName(NAME)).thenReturn(Optional.of(heeUser));
 
-    service.syncRecord(heeUser);
+    heeUserFromTis.setOperation(operation);
+    service.syncRecord(heeUserFromTis);
 
-    verify(repository).save(heeUser);
+    verify(repository).findByName(NAME);
+    verify(repository).deleteById(ID);
+    verify(repository).save(heeUserFromTis);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @ParameterizedTest(name = "Should store records when operation is {0}.")
+  @EnumSource(value = Operation.class, names = {"LOAD", "INSERT", "UPDATE"})
+  void shouldStoreRecordsIfNotExist(Operation operation) {
+    when(repository.findByName(NAME)).thenReturn(Optional.empty());
+
+    heeUserFromTis.setOperation(operation);
+    service.syncRecord(heeUserFromTis);
+
+    verify(repository).findByName(NAME);
+    verify(repository).save(heeUserFromTis);
     verifyNoMoreInteractions(repository);
   }
 
@@ -108,24 +130,45 @@ class HeeUserSyncServiceTest {
   void shouldDeleteRecordFromStoreIfExists() {
     when(repository.findByName(NAME)).thenReturn(Optional.of(heeUser));
 
-    HeeUser heeUserFromTis = new HeeUser(); //arrives without ID
     heeUserFromTis.setOperation(DELETE);
-    heeUserFromTis.setData(Map.of("name", NAME));
     service.syncRecord(heeUserFromTis);
 
     verify(repository).findByName(NAME);
-    verify(repository).deleteById(NAME);
+    verify(repository).deleteById(ID);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldNotDeleteRecordFromStoreIfNotExists() {
-    heeUser.setOperation(DELETE);
     when(repository.findByName(NAME)).thenReturn(Optional.empty());
 
-    service.syncRecord(heeUser);
+    heeUserFromTis.setOperation(DELETE);
+    service.syncRecord(heeUserFromTis);
 
     verify(repository).findByName(NAME);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldFindRecordByIdWhenExists() {
+    when(repository.findById(ID)).thenReturn(Optional.of(heeUser));
+
+    Optional<HeeUser> found = service.findById(ID);
+    assertThat("Record not found.", found.isPresent(), is(true));
+    assertThat("Unexpected record.", found.orElse(null), sameInstance(heeUser));
+
+    verify(repository).findById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotFindRecordByIdWhenNotExists() {
+    when(repository.findById(ID)).thenReturn(Optional.empty());
+
+    Optional<HeeUser> found = service.findById(ID);
+    assertThat("Record not found.", found.isEmpty(), is(true));
+
+    verify(repository).findById(ID);
     verifyNoMoreInteractions(repository);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
@@ -81,6 +81,7 @@ class HeeUserSyncServiceTest {
 
     heeUser = new HeeUser();
     heeUser.setTisId(NAME);
+    heeUser.setData(Map.of("name", NAME));
 
     whereMap = Map.of("name", NAME);
     whereMap2 = Map.of("name", NAME_2);
@@ -104,12 +105,25 @@ class HeeUserSyncServiceTest {
   }
 
   @Test
-  void shouldDeleteRecordFromStore() {
+  void shouldDeleteRecordFromStoreIfExists() {
     heeUser.setOperation(DELETE);
+    when(repository.findByName(NAME)).thenReturn(Optional.of(heeUser));
 
     service.syncRecord(heeUser);
 
+    verify(repository).findByName(NAME);
     verify(repository).deleteById(NAME);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotDeleteRecordFromStoreIfNotExists() {
+    heeUser.setOperation(DELETE);
+    when(repository.findByName(NAME)).thenReturn(Optional.empty());
+
+    service.syncRecord(heeUser);
+
+    verify(repository).findByName(NAME);
     verifyNoMoreInteractions(repository);
   }
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
@@ -106,10 +106,12 @@ class HeeUserSyncServiceTest {
 
   @Test
   void shouldDeleteRecordFromStoreIfExists() {
-    heeUser.setOperation(DELETE);
     when(repository.findByName(NAME)).thenReturn(Optional.of(heeUser));
 
-    service.syncRecord(heeUser);
+    HeeUser heeUserFromTis = new HeeUser(); //arrives without ID
+    heeUserFromTis.setOperation(DELETE);
+    heeUserFromTis.setData(Map.of("name", NAME));
+    service.syncRecord(heeUserFromTis);
 
     verify(repository).findByName(NAME);
     verify(repository).deleteById(NAME);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/HeeUserSyncServiceTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.event.HeeUserEventListener.HEE_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -85,12 +86,12 @@ class HeeUserSyncServiceTest {
 
     heeUser = new HeeUser();
     heeUser.setTisId(ID);
-    heeUser.setData(Map.of("name", NAME, "emailAddress", EMAIL));
+    heeUser.setData(Map.of(HEE_USER_NAME, NAME, "emailAddress", EMAIL));
     heeUserFromTis = new HeeUser(); //arrives without ID
-    heeUserFromTis.setData(Map.of("name", NAME, "emailAddress", EMAIL_2));
+    heeUserFromTis.setData(Map.of(HEE_USER_NAME, NAME, "emailAddress", EMAIL_2));
 
-    whereMap = Map.of("name", NAME);
-    whereMap2 = Map.of("name", NAME_2);
+    whereMap = Map.of(HEE_USER_NAME, NAME);
+    whereMap2 = Map.of(HEE_USER_NAME, NAME_2);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class UserDesignatedBodySyncServiceTest {
   private static final String ID = "UserDesignatedBodyId";
   private static final String ID_2 = "UserDesignatedBodyId2";
   private static final String DBC = "dbc";
+  private static final String USERNAME = "theUser";
 
   private UserDesignatedBodySyncService service;
   private UserDesignatedBodyRepository repository;
@@ -62,8 +64,10 @@ class UserDesignatedBodySyncServiceTest {
 
     userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(ID);
+    userDesignatedBody.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
     userDesignatedBody2 = new UserDesignatedBody();
     userDesignatedBody2.setTisId(ID_2);
+    userDesignatedBody2.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
   }
 
   @Test
@@ -84,12 +88,27 @@ class UserDesignatedBodySyncServiceTest {
   }
 
   @Test
-  void shouldDeleteRecordFromStore() {
+  void shouldDeleteRecordFromStoreIfExists() {
     userDesignatedBody.setOperation(DELETE);
+    when(repository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
+        .thenReturn(Optional.of(userDesignatedBody));
 
     service.syncRecord(userDesignatedBody);
 
+    verify(repository).findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotDeleteRecordFromStoreIfNotExists() {
+    userDesignatedBody.setOperation(DELETE);
+    when(repository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
+        .thenReturn(Optional.empty());
+
+    service.syncRecord(userDesignatedBody);
+
+    verify(repository).findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     verifyNoMoreInteractions(repository);
   }
 
@@ -118,74 +137,75 @@ class UserDesignatedBodySyncServiceTest {
 
   @Test
   void shouldFindByUserNameWhenExists() {
-    when(repository.findByUserName(ID)).thenReturn(Set.of(userDesignatedBody, userDesignatedBody2));
+    when(repository.findByUserName(USERNAME))
+        .thenReturn(Set.of(userDesignatedBody, userDesignatedBody2));
 
-    Set<UserDesignatedBody> found = service.findByUserName(ID);
+    Set<UserDesignatedBody> found = service.findByUserName(USERNAME);
     assertThat("Unexpected number of records.", found.size(), is(2));
     assertThat("Unexpected record.", found.contains(userDesignatedBody), is(true));
     assertThat("Unexpected record.", found.contains(userDesignatedBody2), is(true));
 
-    verify(repository).findByUserName(ID);
+    verify(repository).findByUserName(USERNAME);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldNotFindByUserNameWhenNotExists() {
-    when(repository.findByUserName(ID)).thenReturn(Set.of());
+    when(repository.findByUserName(USERNAME)).thenReturn(Set.of());
 
-    Set<UserDesignatedBody> found = service.findByUserName(ID);
+    Set<UserDesignatedBody> found = service.findByUserName(USERNAME);
     assertThat("Record not found.", found.isEmpty(), is(true));
 
-    verify(repository).findByUserName(ID);
+    verify(repository).findByUserName(USERNAME);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldFindByDbcWhenExists() {
-    when(repository.findByDbc(ID)).thenReturn(Set.of(userDesignatedBody, userDesignatedBody2));
+    when(repository.findByDbc(DBC)).thenReturn(Set.of(userDesignatedBody, userDesignatedBody2));
 
-    Set<UserDesignatedBody> found = service.findByDbc(ID);
+    Set<UserDesignatedBody> found = service.findByDbc(DBC);
     assertThat("Unexpected number of records.", found.size(), is(2));
     assertThat("Unexpected record.", found.contains(userDesignatedBody), is(true));
     assertThat("Unexpected record.", found.contains(userDesignatedBody2), is(true));
 
-    verify(repository).findByDbc(ID);
+    verify(repository).findByDbc(DBC);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldNotFindByDbcWhenNotExists() {
-    when(repository.findByDbc(ID)).thenReturn(Set.of());
+    when(repository.findByDbc(DBC)).thenReturn(Set.of());
 
-    Set<UserDesignatedBody> found = service.findByDbc(ID);
+    Set<UserDesignatedBody> found = service.findByDbc(DBC);
     assertThat("Record not found.", found.isEmpty(), is(true));
 
-    verify(repository).findByDbc(ID);
+    verify(repository).findByDbc(DBC);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldFindRecordByUserNameAndDesignatedBodyCodeWhenExists() {
-    when(repository.findByUserNameAndDesignatedBodyCode(ID, DBC))
+    when(repository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
         .thenReturn(Optional.of(userDesignatedBody));
 
-    Optional<UserDesignatedBody> found = service.findByUserNameAndDesignatedBodyCode(ID, DBC);
+    Optional<UserDesignatedBody> found = service.findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     assertThat("Record not found.", found.isPresent(), is(true));
     assertThat("Unexpected record.", found.orElse(null), sameInstance(userDesignatedBody));
 
-    verify(repository).findByUserNameAndDesignatedBodyCode(ID, DBC);
+    verify(repository).findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     verifyNoMoreInteractions(repository);
   }
 
   @Test
   void shouldNotFindRecordByUserNameAndDesignatedBodyCodeWhenNotExists() {
-    when(repository.findByUserNameAndDesignatedBodyCode(ID, DBC))
+    when(repository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
         .thenReturn(Optional.empty());
 
-    Optional<UserDesignatedBody> found = service.findByUserNameAndDesignatedBodyCode(ID, DBC);
+    Optional<UserDesignatedBody> found = service.findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     assertThat("Record not found.", found.isEmpty(), is(true));
 
-    verify(repository).findByUserNameAndDesignatedBodyCode(ID, DBC);
+    verify(repository).findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     verifyNoMoreInteractions(repository);
   }
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
@@ -89,11 +89,13 @@ class UserDesignatedBodySyncServiceTest {
 
   @Test
   void shouldDeleteRecordFromStoreIfExists() {
-    userDesignatedBody.setOperation(DELETE);
     when(repository.findByUserNameAndDesignatedBodyCode(USERNAME, DBC))
         .thenReturn(Optional.of(userDesignatedBody));
 
-    service.syncRecord(userDesignatedBody);
+    UserDesignatedBody userDesignatedBodyFromTis = new UserDesignatedBody(); //arrives without ID
+    userDesignatedBodyFromTis.setOperation(DELETE);
+    userDesignatedBodyFromTis.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
+    service.syncRecord(userDesignatedBodyFromTis);
 
     verify(repository).findByUserNameAndDesignatedBodyCode(USERNAME, DBC);
     verify(repository).deleteById(ID);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserDesignatedBodySyncServiceTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_DBC;
+import static uk.nhs.hee.tis.trainee.sync.event.UserDesignatedBodyEventListener.USER_DB_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import java.util.Map;
@@ -65,12 +67,12 @@ class UserDesignatedBodySyncServiceTest {
 
     userDesignatedBody = new UserDesignatedBody();
     userDesignatedBody.setTisId(ID);
-    userDesignatedBody.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
+    userDesignatedBody.setData(Map.of(USER_DB_USER_NAME, USERNAME, USER_DB_DBC, DBC));
     userDesignatedBody2 = new UserDesignatedBody();
     userDesignatedBody2.setTisId(ID_2);
-    userDesignatedBody2.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
+    userDesignatedBody2.setData(Map.of(USER_DB_USER_NAME, USERNAME, USER_DB_DBC, DBC));
     userDesignatedBodyFromTis = new UserDesignatedBody(); //no ID
-    userDesignatedBodyFromTis.setData(Map.of("userName", USERNAME, "designatedBodyCode", DBC));
+    userDesignatedBodyFromTis.setData(Map.of(USER_DB_USER_NAME, USERNAME, USER_DB_DBC, DBC));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
@@ -83,11 +83,13 @@ class UserRoleSyncServiceTest {
 
   @Test
   void shouldDeleteRecordFromStoreIfExists() {
-    userRole.setOperation(DELETE);
     when(repository.findByUserNameAndRoleName(USERNAME, ROLENAME))
         .thenReturn(Optional.of(userRole));
 
-    service.syncRecord(userRole);
+    UserRole userRoleFromTis = new UserRole(); //arrives without ID
+    userRoleFromTis.setOperation(DELETE);
+    userRoleFromTis.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
+    service.syncRecord(userRoleFromTis);
 
     verify(repository).findByUserNameAndRoleName(USERNAME, ROLENAME);
     verify(repository).deleteById(ID);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,8 @@ import uk.nhs.hee.tis.trainee.sync.repository.UserRoleRepository;
 class UserRoleSyncServiceTest {
 
   private static final String ID = "UserRoleId";
+  private static final String USERNAME = "theUser";
+  private static final String ROLENAME = "theRole";
 
   private UserRoleSyncService service;
   private UserRoleRepository repository;
@@ -58,6 +61,7 @@ class UserRoleSyncServiceTest {
 
     userRole = new UserRole();
     userRole.setTisId(ID);
+    userRole.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
   }
 
   @Test
@@ -78,12 +82,27 @@ class UserRoleSyncServiceTest {
   }
 
   @Test
-  void shouldDeleteRecordFromStore() {
+  void shouldDeleteRecordFromStoreIfExists() {
     userRole.setOperation(DELETE);
+    when(repository.findByUserNameAndRoleName(USERNAME, ROLENAME))
+        .thenReturn(Optional.of(userRole));
 
     service.syncRecord(userRole);
 
+    verify(repository).findByUserNameAndRoleName(USERNAME, ROLENAME);
     verify(repository).deleteById(ID);
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldNotDeleteRecordFromStoreIfNotExists() {
+    userRole.setOperation(DELETE);
+    when(repository.findByUserNameAndRoleName(USERNAME, ROLENAME))
+        .thenReturn(Optional.empty());
+
+    service.syncRecord(userRole);
+
+    verify(repository).findByUserNameAndRoleName(USERNAME, ROLENAME);
     verifyNoMoreInteractions(repository);
   }
 
@@ -132,4 +151,5 @@ class UserRoleSyncServiceTest {
     verify(repository).findRvOfficerRoleByUserName(ID);
     verifyNoMoreInteractions(repository);
   }
+
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/UserRoleSyncServiceTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_ROLE_NAME;
+import static uk.nhs.hee.tis.trainee.sync.event.UserRoleEventListener.USER_ROLE_USER_NAME;
 import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
 
 import java.util.Map;
@@ -62,9 +64,9 @@ class UserRoleSyncServiceTest {
 
     userRole = new UserRole();
     userRole.setTisId(ID);
-    userRole.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
+    userRole.setData(Map.of(USER_ROLE_USER_NAME, USERNAME, USER_ROLE_ROLE_NAME, ROLENAME));
     userRoleFromTis = new UserRole(); //arrives without ID
-    userRoleFromTis.setData(Map.of("userName", USERNAME, "roleName", ROLENAME));
+    userRoleFromTis.setData(Map.of(USER_ROLE_USER_NAME, USERNAME, USER_ROLE_ROLE_NAME, ROLENAME));
   }
 
   @Test

--- a/src/test/resources/application-int.yml
+++ b/src/test/resources/application-int.yml
@@ -1,3 +1,6 @@
+mongock:
+  enabled: false
+
 spring:
   cloud:
     aws:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,2 @@
+mongock:
+  enabled: false


### PR DESCRIPTION
For tables with no ID field, query the database to see if the incoming record is already there and to get a usable ID field for caching purposes. 

Delete:
Use the retrieved ID for the delete, or ignore if the record was not found.

Insert:
For UserRole and UserDesignatedBody, load/insert for existing records is ignored (since there are no additional fields beyond the composite key); for HeeUser the old record is first deleted since other field values might have been updated in the new record.

Mongock to recreate the tables:
These will be populated by redriving the applicable tables in TIS. Existing Responsible Officer entries in trainee profiles are currently correct (afaik), hence the collections can be dropped and recreated instead of deleting all records (which would trigger updates to profiles for each deletion).

Create unique compound indexes for applicable tables to ensure no duplicate records can be created. This could also be added to the Mongo config once the tables are cleaned and do not have duplicates.
 
TIS21-6788
TIS21-6795