### PR TITLE
fix(pm): always delete in downstream services

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.18.6"
+version = "1.18.7"
 
 configurations {
   compileOnly {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingProgrammeMembershipIntTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/cache/CachingProgrammeMembershipIntTest.java
@@ -52,6 +52,7 @@ import uk.nhs.hee.tis.trainee.sync.model.ProgrammeMembership;
 import uk.nhs.hee.tis.trainee.sync.model.Record;
 import uk.nhs.hee.tis.trainee.sync.repository.ProgrammeMembershipRepository;
 import uk.nhs.hee.tis.trainee.sync.service.ProgrammeMembershipSyncService;
+import uk.nhs.hee.tis.trainee.sync.service.TcsSyncService;
 
 @SpringBootTest(properties = {"cloud.aws.region.static=eu-west-2"})
 @ActiveProfiles("int")
@@ -66,6 +67,9 @@ class CachingProgrammeMembershipIntTest {
 
   @MockBean
   private SqsTemplate sqsTemplate;
+
+  @MockBean
+  private TcsSyncService tcsService;
 
   @Autowired
   ProgrammeMembershipSyncService programmeMembershipSyncService;


### PR DESCRIPTION
Currently if a DELETE message is received but no matching PM is found in the sync database the AfterDeleteEvent listener does not fire and downstream services are not notified of the potential deletion.

In most cases this is fine, as the deletion has already occured, but in edge cases where the DELETE message is required again (e.g. cleaning up partial/leftover data from previously failed deletes) the message never makes it to the downstream services leaving them out of date with no way to automatically sync back up.

The original intention of the PM event listener was that it would fire on database events, allowing async handling of updates and deletes de-coupled from the incoming record messages. However, the implementation uses application events instead, which offer no such benefits. As a result the event listeners offer nothing other than complexity/obscurity given the current needs.

Remove the delete handling from the ProgrammeMembershipEventListener and update the ProgrammeMembershipSyncService to call the TCS sync directly. This simplifies the application flow as well as removing the need for cache trickery to keep data available after deletion. Due to a circular dependency issue the "on save" aspects of the event listener have not been removed at this time, as more significant refactoring would be required than I'm willing to tackle as part of boy scouting.

TIS21-6701