### PR TITLE
feat: include TIS trigger metadata

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.18.7"
+version = "1.19.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapper.java
@@ -39,6 +39,8 @@ public interface RecordMapper {
   @Mapping(target = "type", source = "metadata", qualifiedBy = RecordType.class)
   @Mapping(target = "schema", source = "metadata.schema-name")
   @Mapping(target = "table", source = "metadata.table-name")
+  @Mapping(target = "tisTrigger", source = "metadata.tis-trigger")
+  @Mapping(target = "tisTriggerDetail", source = "metadata.tis-trigger-detail")
   Record toEntity(RecordDto recordDto);
 
   void copy(Record source, @MappingTarget Record target);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
@@ -27,6 +27,9 @@ import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 
+/**
+ * A generic TIS record class containing data and metadata to represent a database record event.
+ */
 @Data
 public class Record {
 

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/model/Record.java
@@ -48,4 +48,10 @@ public class Record {
 
   @Transient
   private String table;
+
+  @Transient
+  private String tisTrigger;
+
+  @Transient
+  private String tisTriggerDetail;
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/RecordMapperTest.java
@@ -49,6 +49,10 @@ class RecordMapperTest {
   private static final String TYPE_VALUE = "data";
   private static final String OPERATION_FIELD = "operation";
   private static final String OPERATION_VALUE = "load";
+  private static final String TIS_TRIGGER_FIELD = "tis-trigger";
+  private static final String TIS_TRIGGER = "Update rejected";
+  private static final String TIS_TRIGGER_DETAIL_FIELD = "tis-trigger-detail";
+  private static final String TIS_TRIGGER_DETAIL = "Some details about this";
 
   @Autowired
   private RecordMapper mapper;
@@ -58,7 +62,9 @@ class RecordMapperTest {
   void setUp() {
     recordMetadata = Map.ofEntries(
         Map.entry(TYPE_FIELD, TYPE_VALUE),
-        Map.entry(OPERATION_FIELD, OPERATION_VALUE)
+        Map.entry(OPERATION_FIELD, OPERATION_VALUE),
+        Map.entry(TIS_TRIGGER_FIELD, TIS_TRIGGER),
+        Map.entry(TIS_TRIGGER_DETAIL_FIELD, TIS_TRIGGER_DETAIL)
     );
   }
 
@@ -100,5 +106,16 @@ class RecordMapperTest {
 
     Record record = mapper.toEntity(recordDto);
     assertThat("Unexpected tisId.", record.getTisId(), is(UUID_VALUE));
+  }
+
+  @Test
+  void shouldMapTisTrigger() {
+    RecordDto recordDto = new RecordDto();
+    recordDto.setMetadata(recordMetadata);
+
+    Record recrd = mapper.toEntity(recordDto);
+    assertThat("Unexpected tisTrigger.", recrd.getTisTrigger(), is(TIS_TRIGGER));
+    assertThat("Unexpected tisTriggerDetail.", recrd.getTisTriggerDetail(),
+        is(TIS_TRIGGER_DETAIL));
   }
 }


### PR DESCRIPTION
...in notification SNS messages for downstream handling.

With the changes to data requests in tis-sync as per https://github.com/Health-Education-England/TIS-SYNC/pull/257 the expected message arriving in the tis-trainee-sync record queue should include additional metadata fields like
```
{
  "data": {
    "id": 47165,
    "gmcNumber": "7962465",
    "gmcStatus": "Registered with License",
    "amendedDate": "202-01-01T09:46:00Z"
  },
  "metadata": {
    "timestamp": "2024-12-10T12:01:45.221849Z",
    "record-type": "data",
    "operation": "update",
    "partition-key-type": "schema-table",
    "schema-name": "tcs",
    "table-name": "GmcDetails",
    "transaction-id": 29222969333729,
    "tis-trigger": "Update rejected",   <---- new
    "tis-trigger-detail": "blah blah blah"  <---- new
  }
}
```
the record should be synced as normal, which will revert the trainee's edit, and the additional fields are included in the message published to SNS, for handling by the notification service to provide an email notification to the trainee https://github.com/Health-Education-England/tis-trainee-sync/blob/8c4c21212867a63b89d603cf731849d5966360d8/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java#L164

TIS21-6640