### PR TITLE
fix: tis trigger must be a leaf node for SNS subscription filtering

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.19.0"
+version = "1.19.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -185,8 +185,10 @@ public class TcsSyncService implements SyncService {
     if (snsTopic != null) {
       // record change should be broadcast
       Map<String, Object> treeValues = null;
-      if (recrd.getOperation() == DELETE || recrd.getOperation() == INSERT
-          || recrd.getOperation() == LOAD || recrd.getOperation() == UPDATE) {
+      if (recrd.getOperation()    == DELETE
+          || recrd.getOperation() == INSERT
+          || recrd.getOperation() == LOAD
+          || recrd.getOperation() == UPDATE) {
         treeValues = new HashMap<>();
         treeValues.put("tisId", recrd.getTisId());
         treeValues.put("record", recrd);

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -21,9 +21,15 @@
 
 package uk.nhs.hee.tis.trainee.sync.service;
 
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.DELETE;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.INSERT;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.LOAD;
+import static uk.nhs.hee.tis.trainee.sync.model.Operation.UPDATE;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -179,15 +185,19 @@ public class TcsSyncService implements SyncService {
 
     if (snsTopic != null) {
       // record change should be broadcast
-      Map<String, Object> treeValues = switch (recrd.getOperation()) {
-        case DELETE, INSERT, LOAD, UPDATE -> Map.of(
-            "tisId", recrd.getTisId(),
-            "tisTrigger", Objects.toString(recrd.getTisTrigger(), ""),
-            "tisTriggerDetail", Objects.toString(recrd.getTisTriggerDetail(), ""),
-            "record", recrd
-        );
-        default -> null; //should never happen
-      };
+      Map<String, Object> treeValues = null;
+      if (recrd.getOperation() == DELETE || recrd.getOperation() == INSERT
+          || recrd.getOperation() == LOAD || recrd.getOperation() == UPDATE) {
+        treeValues = new HashMap<>();
+        treeValues.put("tisId", recrd.getTisId());
+        treeValues.put("record", recrd);
+        if (recrd.getTisTrigger() != null) {
+          treeValues.put("tisTrigger", recrd.getTisTrigger());
+        }
+        if (recrd.getTisTriggerDetail() != null) {
+          treeValues.put("tisTriggerDetail", recrd.getTisTriggerDetail());
+        }
+      }
 
       if (treeValues != null) {
         JsonNode eventJson = objectMapper.valueToTree(treeValues);
@@ -214,7 +224,7 @@ public class TcsSyncService implements SyncService {
    */
   public void publishDetailsChangeEvent(ProgrammeMembershipEventDto programmeMembershipEventDto) {
     PublishRequest request = null;
-    SnsRoute snsTopic = tableToSnsTopic(ConditionsOfJoining.ENTITY_NAME, Operation.UPDATE);
+    SnsRoute snsTopic = tableToSnsTopic(ConditionsOfJoining.ENTITY_NAME, UPDATE);
 
     if (snsTopic != null && programmeMembershipEventDto != null) {
       JsonNode eventJson = objectMapper.valueToTree(programmeMembershipEventDto);
@@ -343,7 +353,7 @@ public class TcsSyncService implements SyncService {
         restTemplate.delete(serviceUrl + API_DELETE_PROFILE_TEMPLATE, dto.getTraineeTisId());
         personService.deleteById(dto.getTraineeTisId());
       } else if (apiPath.equals(TABLE_NAME_TO_API_PATH.get(TABLE_QUALIFICATION))) {
-        log.warn("Unhandled Qualification operation {}.", Operation.DELETE);
+        log.warn("Unhandled Qualification operation {}.", DELETE);
       } else {
         TraineeDetailsDto emptyDto = new TraineeDetailsDto();
         restTemplate.patchForObject(serviceUrl + API_ID_TEMPLATE, emptyDto, Object.class, apiPath,

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncService.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
@@ -181,6 +182,8 @@ public class TcsSyncService implements SyncService {
       Map<String, Object> treeValues = switch (recrd.getOperation()) {
         case DELETE, INSERT, LOAD, UPDATE -> Map.of(
             "tisId", recrd.getTisId(),
+            "tisTrigger", Objects.toString(recrd.getTisTrigger(), ""),
+            "tisTriggerDetail", Objects.toString(recrd.getTisTriggerDetail(), ""),
             "record", recrd
         );
         default -> null; //should never happen

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -823,11 +823,26 @@ class TcsSyncServiceTest {
   }
 
   /**
+   * Provide the cartesian product of the tables and all operations that should trigger events.
+   *
+   * @return The stream of arguments.
+   */
+  private static Stream<Arguments> provideAllEventParameters() {
+    return Stream.of(UPDATE, LOAD, INSERT, DELETE).flatMap(operation ->
+        Stream.of(TABLE_CONTACT_DETAILS, TABLE_GDC_DETAILS, TABLE_GMC_DETAILS, TABLE_PERSON_OWNER,
+                TABLE_PERSONAL_DETAILS, TABLE_PLACEMENT, TABLE_PROGRAMME_MEMBERSHIP)
+            .flatMap(table -> Stream.of(
+                Arguments.of(operation, table)
+            ))
+    );
+  }
+
+  /**
    * Provide the cartesian product of the tables and update operations that should trigger events.
    *
    * @return The stream of arguments.
    */
-  private static Stream<Arguments> provideUpdateParameters() {
+  private static Stream<Arguments> provideOnlyUpdateParameters() {
     return Stream.of(UPDATE, LOAD, INSERT).flatMap(operation ->
         Stream.of(TABLE_CONTACT_DETAILS, TABLE_GDC_DETAILS, TABLE_GMC_DETAILS, TABLE_PERSON_OWNER,
                 TABLE_PERSONAL_DETAILS, TABLE_PLACEMENT, TABLE_PROGRAMME_MEMBERSHIP)
@@ -838,7 +853,7 @@ class TcsSyncServiceTest {
   }
 
   @ParameterizedTest(name = "Should issue update event when operation is {0} and table is {1}")
-  @MethodSource("provideUpdateParameters")
+  @MethodSource("provideOnlyUpdateParameters")
   void shouldIssueEventForSpecifiedTablesWhenOperationUpdate(Operation operation, String table)
       throws JsonProcessingException {
     Map<String, String> data = Map.of("traineeId", "traineeIdValue");
@@ -893,7 +908,7 @@ class TcsSyncServiceTest {
   }
 
   @ParameterizedTest
-  @MethodSource("provideUpdateParameters")
+  @MethodSource("provideAllEventParameters")
   void shouldSetMessageGroupIdOnIssuedEventWhenFifoQueue(Operation operation, String table) {
     Map<String, String> data = Map.of("traineeId", "traineeIdValue");
 

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/TcsSyncServiceTest.java
@@ -887,10 +887,9 @@ class TcsSyncServiceTest {
     PublishRequest request = requestCaptor.getValue();
     Map<String, String> message = new ObjectMapper().readValue(request.message(), Map.class);
     assertThat("Unexpected event id.", message.get("tisId"), is("idValue"));
-    String expectedTisTrigger = (tisTrigger == null? "" : tisTrigger);
-    assertThat("Unexpected tisTrigger.", message.get("tisTrigger"), is(expectedTisTrigger));
+    assertThat("Unexpected tisTrigger.", message.get("tisTrigger"), is(tisTrigger));
     assertThat("Unexpected tisTriggerDetail.", message.get("tisTriggerDetail"),
-        is(expectedTisTrigger));
+        is(tisTrigger));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
From the AWS docs: "exists matching only works on leaf nodes. It does not work on intermediate nodes." . This means the tisTrigger attribute inside the record is ignored. Our subscription filter is 
```
{
  "tisTrigger": [
    {
      "exists": true
    }
  ]
}
```
Unfortunately the change does nothing to make our message any less verbose. Example:

```
{
  "tisId" : "47165",
  "tisTrigger" : "Update rejected",
  "tisTriggerDetail" : "Received 2025-01-14T09:25:02.125",
  "record" : {
    "tisId" : "47165",
    "data" : {
      "id" : "47165",
      "gmcNumber" : "UNKNOWN",
      "gmcStatus" : "Registered with Licence",
      "amendedDate" : "2024-10-10T09:24:08.428"
    },
    "metadata" : {
      "timestamp" : "2025-01-14T09:25:23.178Z",
      "record-type" : "data",
      "operation" : "load",
      "partition-key-type" : "schema-table",
      "schema-name" : "tcs",
      "table-name" : "GmcDetails",
      "transaction-id" : "6c921945-5114-47fd-a046-2e77fcc1538c",
      "tis-trigger" : "Update rejected",
      "tis-trigger-detail" : "Received 2025-01-14T09:25:02.125"
    },
    "type" : "DATA",
    "operation" : "LOAD",
    "schema" : "tcs",
    "table" : "GmcDetails",
    "tisTrigger" : "Update rejected",
    "tisTriggerDetail" : "Received 2025-01-14T09:25:02.125"
  }
}
```

(Note that empty string tisTrigger values will match the subscription filter, hence the clumsy rewrite; I assume AWS mean `[]` for empty when they write "The key must have a non-null and non-empty value")

I could tweak things so the new attributes are not included as record.tisTrigger and record.tisTriggerDetail, but it feels like that would just be laying a trap for someone without a more consistent rework of the entire message structure. 🤷 

TIS21-6640