### PR TITLE
feat: include DBC in programme membership

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.19.2"
+version = "1.20.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/dto/AggregateProgrammeMembershipDto.java
@@ -39,6 +39,7 @@ public class AggregateProgrammeMembershipDto {
   private String programmeNumber;
   private String managingDeanery;
   private String designatedBody;
+  private String designatedBodyCode;
   private String programmeMembershipType;
   private LocalDate startDate;
   private LocalDate endDate;

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -93,6 +93,7 @@ public interface AggregateMapper {
   @Mapping(target = "programmeNumber", source = "programme.data.programmeNumber")
   @Mapping(target = "managingDeanery", source = "programme.data.owner")
   @Mapping(target = "designatedBody", source = "dbc.data.name")
+  @Mapping(target = "designatedBodyCode", source = "dbc.data.dbc")
   @Mapping(target = "programmeCompletionDate", ignore = true)
   @Mapping(target = "trainingPathway", source = "programmeMembership.trainingPathway")
   @Mapping(target = "curricula", source = "curricula")

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -146,6 +146,7 @@ class ProgrammeMembershipEnricherFacadeTest {
   private static final String PROGRAMME_MEMBERSHIP_DATA_PROGRAMME_NUMBER = "programmeNumber";
   private static final String PROGRAMME_MEMBERSHIP_DATA_MANAGING_DEANERY = "managingDeanery";
   private static final String PROGRAMME_MEMBERSHIP_DATA_DESIGNATED_BODY = "designatedBody";
+  private static final String PROGRAMME_MEMBERSHIP_DATA_DESIGNATED_BODY_CODE = "designatedBodyCode";
   private static final String PROGRAMME_MEMBERSHIP_DATA_CONDITIONS_OF_JOINING
       = "conditionsOfJoining";
   private static final String PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER = "responsibleOfficer";
@@ -266,6 +267,9 @@ class ProgrammeMembershipEnricherFacadeTest {
     assertThat("Unexpected designated body.",
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_DESIGNATED_BODY),
         is(DBC_NAME_VALUE));
+    assertThat("Unexpected designated body code.",
+        programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_DESIGNATED_BODY_CODE),
+        is(DBC_DBC_VALUE));
 
     Set<Map<String, String>> curricula = new ObjectMapper().readValue(
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_CURRICULA), new TypeReference<>() {

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
@@ -346,7 +346,7 @@ class AggregateMapperTest {
     assertThat("Unexpected TIS ID.", record.getTisId(), is(PROGRAMME_MEMBERSHIP_ID.toString()));
 
     Map<String, String> recordData = record.getData();
-    assertThat("Unexpected record data count.", recordData.size(), is(15));
+    assertThat("Unexpected record data count.", recordData.size(), is(16));
     assertThat("Unexpected TIS ID.", recordData.get("tisId"),
         is(PROGRAMME_MEMBERSHIP_ID.toString()));
     assertThat("Unexpected person ID.", recordData.get("personId"), is(TRAINEE_ID));


### PR DESCRIPTION
The admin endpoints for LTFT forms require filtering based on the admin's local office, which can be determined using the `cognito:groups` from the auth token.
The group name is the DBC, rather than a name, so to avoid having to hardcode a mapping the code should be added to the PM so it can be referenced in the LTFT data.

TIS21-6599
TIS21-6938