### PR TITLE
build: enable build scan publishing when debugging

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,11 +6,20 @@ on:
       - main
 
 jobs:
+  get-context:
+    name: Check if debug enabled
+    runs-on: ubuntu-latest
+    outputs:
+      runner-debug: ${{ runner.debug }}
+    steps:
+      - run: echo "Loading context variables"
   ci-cd:
     name: Build and deploy
+    needs: get-context
     uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
     with:
       cluster-prefix: trainee
+      publish-build-scan: ${{ needs.get-context.outputs.runner-debug == '1' }}
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       reject-pat: ${{ secrets.PAT_REJECT_APPROVALS }}

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -6,8 +6,18 @@ on:
       - main
 
 jobs:
+  get-context:
+    name: Check if debug enabled
+    runs-on: ubuntu-latest
+    outputs:
+      runner-debug: ${{ runner.debug }}
+    steps:
+      - run: echo "Loading context variables"
   analysis:
     name: Analyse PR
+    needs: get-context
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
+    with:
+      publish-build-scan: ${{ needs.get-context.outputs.runner-debug == '1' }}
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
When debug logging is enabled in GitHub Actions the publishing of Gradle build scans should be enabled to assist in debugging.

NO-TICKET