### PR TITLE
fix: handle nulls in toRecord mapper

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.21.0"
+version = "1.21.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -130,14 +130,13 @@ public interface AggregateMapper {
         });
 
     try {
-      // Restore the DTO to its original state and set the curricula and conditions of joining
-      // record data.
       aggregateProgrammeMembershipDto.setCurricula(curricula);
-      recordData.put("curricula", objectMapper.writeValueAsString(curricula));
       aggregateProgrammeMembershipDto.setConditionsOfJoining(conditionsOfJoining);
-      recordData.put("conditionsOfJoining", objectMapper.writeValueAsString(conditionsOfJoining));
       aggregateProgrammeMembershipDto.setResponsibleOfficer(responsibleOfficer);
-      recordData.put("responsibleOfficer", objectMapper.writeValueAsString(responsibleOfficer));
+
+      serializeFieldNullSafe(recordData, "curricula", curricula, objectMapper);
+      serializeFieldNullSafe(recordData, "conditionsOfJoining", conditionsOfJoining, objectMapper);
+      serializeFieldNullSafe(recordData, "responsibleOfficer", responsibleOfficer, objectMapper);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
@@ -146,6 +145,25 @@ public interface AggregateMapper {
     programmeMembershipRecord.setData(recordData);
     programmeMembershipRecord.setTisId(aggregateProgrammeMembershipDto.getTisId());
     return programmeMembershipRecord;
+  }
+
+  /**
+   * Serialize a field into the record data map, handling null values correctly.
+   *
+   * @param recordData The map to store the serialized field.
+   * @param fieldName  The name of the field to serialize.
+   * @param value      The value to serialize. If null, the field will be set to null in the map,
+   *                   instead of "null".
+   * @param mapper     The ObjectMapper to use for serialization.
+   * @throws JsonProcessingException If there is an error during serialization.
+   */
+  default void serializeFieldNullSafe(Map<String, String> recordData, String fieldName,
+      Object value, ObjectMapper mapper) throws JsonProcessingException {
+    if (value != null) {
+      recordData.put(fieldName, mapper.writeValueAsString(value));
+    } else {
+      recordData.put(fieldName, null);
+    }
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -338,11 +338,9 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
+    assertThat("Unexpected responsible officer.",
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        new TypeReference<>() {
-        });
-    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
+        is(nullValue()));
   }
 
   @Test
@@ -362,11 +360,8 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
-        programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        new TypeReference<>() {
-        });
-    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
+    assertThat("Unexpected responsible officer.",
+        programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER), is(nullValue()));
   }
 
   @Test
@@ -387,11 +382,9 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
+    assertThat("Unexpected responsible officer.",
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        new TypeReference<>() {
-        });
-    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
+        is(nullValue()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
@@ -24,6 +24,11 @@ package uk.nhs.hee.tis.trainee.sync.mapper;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -479,5 +484,52 @@ class AggregateMapperTest {
   void shouldParseBooleanWhenStringIsNotTruthy(String strBool) {
     boolean bool = mapper.parseBoolean(strBool);
     assertThat("Unexpected parsed boolean.", bool, is(false));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenJsonProcessingFails() throws JsonProcessingException {
+    AggregateMapper mapperSpy = spy(AggregateMapperImpl.class);
+
+    doThrow(JsonProcessingException.class).when(
+        mapperSpy).serializeFieldNullSafe(anyMap(), any(), any(), any());
+
+    var curriculumMembership = new AggregateCurriculumMembershipDto();
+    curriculumMembership.setCurriculumTisId(CURRICULUM_ID);
+    curriculumMembership.setCurriculumName(CURRICULUM_NAME);
+    curriculumMembership.setCurriculumSubType(CURRICULUM_SUB_TYPE);
+    curriculumMembership.setCurriculumMembershipId(CURRICULUM_MEMBERSHIP_ID);
+    curriculumMembership.setCurriculumStartDate(CURRICULUM_MEMBERSHIP_START_DATE);
+    curriculumMembership.setCurriculumEndDate(CURRICULUM_MEMBERSHIP_END_DATE);
+
+    ConditionsOfJoiningDto conditionsOfJoiningDto = new ConditionsOfJoiningDto();
+    conditionsOfJoiningDto.setSignedAt(SIGNED_AT);
+    conditionsOfJoiningDto.setVersion(VERSION);
+    conditionsOfJoiningDto.setSyncedAt(SYNCED_AT);
+
+    AggregateProgrammeMembershipDto programmeMembership = new AggregateProgrammeMembershipDto();
+    programmeMembership.setTisId(PROGRAMME_MEMBERSHIP_ID.toString());
+    programmeMembership.setPersonId(TRAINEE_ID);
+    programmeMembership.setProgrammeTisId(PROGRAMME_ID);
+    programmeMembership.setProgrammeName(PROGRAMME_NAME);
+    programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER);
+    programmeMembership.setManagingDeanery(PROGRAMME_OWNER);
+    programmeMembership.setDesignatedBody(DBC_NAME);
+    programmeMembership.setDesignatedBodyCode(DBC_CODE);
+    programmeMembership.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
+    programmeMembership.setStartDate(PROGRAMME_MEMBERSHIP_START_DATE);
+    programmeMembership.setEndDate(PROGRAMME_MEMBERSHIP_END_DATE);
+    programmeMembership.setProgrammeCompletionDate(CURRICULUM_MEMBERSHIP_END_DATE);
+    programmeMembership.setCurricula(List.of(curriculumMembership));
+    programmeMembership.setConditionsOfJoining(conditionsOfJoiningDto);
+
+    HeeUserDto roDto = new HeeUserDto();
+    roDto.setFirstName(RO_FIRST_NAME);
+    roDto.setLastName(RO_LAST_NAME);
+    roDto.setEmailAddress(RO_EMAIL);
+    roDto.setGmcId(RO_GMC);
+    roDto.setPhoneNumber(RO_PHONE);
+    programmeMembership.setResponsibleOfficer(roDto);
+
+    assertThrows(RuntimeException.class, () -> mapperSpy.toRecord(programmeMembership));
   }
 }


### PR DESCRIPTION
Using 'writeValueAsString()' on a null value gives the value "null" instead of an actual null.

This causes downstream errors when deserializing into the expected structure, e.g. Caused by: org.springframework.messaging.converter.MessageConversionException: Could not read JSON: Cannot construct instance of `uk.nhs.tis.trainee.actions.dto.ConditionsOfJoiningDto` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('null')

This error has been masked by downstream services only handling CoJ when this would be non-null, but if the actions service is going to handle all PMs the missing/null CoJs needs to be represented correctly.

NO-TICKET