### PR TITLE
Revert "fix: handle nulls in toRecord mapper"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.21.1"
+version = "1.21.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapper.java
@@ -130,13 +130,14 @@ public interface AggregateMapper {
         });
 
     try {
+      // Restore the DTO to its original state and set the curricula and conditions of joining
+      // record data.
       aggregateProgrammeMembershipDto.setCurricula(curricula);
+      recordData.put("curricula", objectMapper.writeValueAsString(curricula));
       aggregateProgrammeMembershipDto.setConditionsOfJoining(conditionsOfJoining);
+      recordData.put("conditionsOfJoining", objectMapper.writeValueAsString(conditionsOfJoining));
       aggregateProgrammeMembershipDto.setResponsibleOfficer(responsibleOfficer);
-
-      serializeFieldNullSafe(recordData, "curricula", curricula, objectMapper);
-      serializeFieldNullSafe(recordData, "conditionsOfJoining", conditionsOfJoining, objectMapper);
-      serializeFieldNullSafe(recordData, "responsibleOfficer", responsibleOfficer, objectMapper);
+      recordData.put("responsibleOfficer", objectMapper.writeValueAsString(responsibleOfficer));
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
@@ -145,25 +146,6 @@ public interface AggregateMapper {
     programmeMembershipRecord.setData(recordData);
     programmeMembershipRecord.setTisId(aggregateProgrammeMembershipDto.getTisId());
     return programmeMembershipRecord;
-  }
-
-  /**
-   * Serialize a field into the record data map, handling null values correctly.
-   *
-   * @param recordData The map to store the serialized field.
-   * @param fieldName  The name of the field to serialize.
-   * @param value      The value to serialize. If null, the field will be set to null in the map,
-   *                   instead of "null".
-   * @param mapper     The ObjectMapper to use for serialization.
-   * @throws JsonProcessingException If there is an error during serialization.
-   */
-  default void serializeFieldNullSafe(Map<String, String> recordData, String fieldName,
-      Object value, ObjectMapper mapper) throws JsonProcessingException {
-    if (value != null) {
-      recordData.put(fieldName, mapper.writeValueAsString(value));
-    } else {
-      recordData.put(fieldName, null);
-    }
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/facade/ProgrammeMembershipEnricherFacadeTest.java
@@ -323,7 +323,8 @@ class ProgrammeMembershipEnricherFacadeTest {
   }
 
   @Test
-  void shouldEnrichProgrammeMembershipWhenResponsibleOfficerHeeUserNotExist() {
+  void shouldEnrichProgrammeMembershipWhenResponsibleOfficerHeeUserNotExist()
+      throws JsonProcessingException {
     final ProgrammeMembership programmeMembership
         = buildEnrichableProgrammeMembershipWithAllMocksEnabled();
 
@@ -337,13 +338,16 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    assertThat("Unexpected responsible officer.",
+    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        is(nullValue()));
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
   }
 
   @Test
-  void shouldEnrichProgrammeMembershipWhenResponsibleOfficerNotExist() {
+  void shouldEnrichProgrammeMembershipWhenResponsibleOfficerNotExist()
+      throws JsonProcessingException {
     final ProgrammeMembership programmeMembership
         = buildEnrichableProgrammeMembershipWithAllMocksEnabled();
 
@@ -358,13 +362,16 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    assertThat("Unexpected responsible officer.",
+    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        is(nullValue()));
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
   }
 
   @Test
-  void shouldEnrichProgrammeMembershipWhenUserDesignatedBodyNotExist() {
+  void shouldEnrichProgrammeMembershipWhenUserDesignatedBodyNotExist()
+      throws JsonProcessingException {
     final ProgrammeMembership programmeMembership
         = buildEnrichableProgrammeMembershipWithAllMocksEnabled();
 
@@ -380,9 +387,11 @@ class ProgrammeMembershipEnricherFacadeTest {
     verify(tcsSyncService).syncRecord(recordCaptor.capture());
 
     Map<String, String> programmeMembershipData = recordCaptor.getValue().getData();
-    assertThat("Unexpected responsible officer.",
+    Map<String, String> responsibleOfficerData = new ObjectMapper().readValue(
         programmeMembershipData.get(PROGRAMME_MEMBERSHIP_DATA_RESPONSIBLE_OFFICER),
-        is(nullValue()));
+        new TypeReference<>() {
+        });
+    assertThat("Unexpected responsible officer.", responsibleOfficerData, is(nullValue()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/mapper/AggregateMapperTest.java
@@ -24,11 +24,6 @@ package uk.nhs.hee.tis.trainee.sync.mapper;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -484,52 +479,5 @@ class AggregateMapperTest {
   void shouldParseBooleanWhenStringIsNotTruthy(String strBool) {
     boolean bool = mapper.parseBoolean(strBool);
     assertThat("Unexpected parsed boolean.", bool, is(false));
-  }
-
-  @Test
-  void shouldThrowExceptionWhenJsonProcessingFails() throws JsonProcessingException {
-    AggregateMapper mapperSpy = spy(AggregateMapperImpl.class);
-
-    doThrow(JsonProcessingException.class).when(
-        mapperSpy).serializeFieldNullSafe(anyMap(), any(), any(), any());
-
-    var curriculumMembership = new AggregateCurriculumMembershipDto();
-    curriculumMembership.setCurriculumTisId(CURRICULUM_ID);
-    curriculumMembership.setCurriculumName(CURRICULUM_NAME);
-    curriculumMembership.setCurriculumSubType(CURRICULUM_SUB_TYPE);
-    curriculumMembership.setCurriculumMembershipId(CURRICULUM_MEMBERSHIP_ID);
-    curriculumMembership.setCurriculumStartDate(CURRICULUM_MEMBERSHIP_START_DATE);
-    curriculumMembership.setCurriculumEndDate(CURRICULUM_MEMBERSHIP_END_DATE);
-
-    ConditionsOfJoiningDto conditionsOfJoiningDto = new ConditionsOfJoiningDto();
-    conditionsOfJoiningDto.setSignedAt(SIGNED_AT);
-    conditionsOfJoiningDto.setVersion(VERSION);
-    conditionsOfJoiningDto.setSyncedAt(SYNCED_AT);
-
-    AggregateProgrammeMembershipDto programmeMembership = new AggregateProgrammeMembershipDto();
-    programmeMembership.setTisId(PROGRAMME_MEMBERSHIP_ID.toString());
-    programmeMembership.setPersonId(TRAINEE_ID);
-    programmeMembership.setProgrammeTisId(PROGRAMME_ID);
-    programmeMembership.setProgrammeName(PROGRAMME_NAME);
-    programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER);
-    programmeMembership.setManagingDeanery(PROGRAMME_OWNER);
-    programmeMembership.setDesignatedBody(DBC_NAME);
-    programmeMembership.setDesignatedBodyCode(DBC_CODE);
-    programmeMembership.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE);
-    programmeMembership.setStartDate(PROGRAMME_MEMBERSHIP_START_DATE);
-    programmeMembership.setEndDate(PROGRAMME_MEMBERSHIP_END_DATE);
-    programmeMembership.setProgrammeCompletionDate(CURRICULUM_MEMBERSHIP_END_DATE);
-    programmeMembership.setCurricula(List.of(curriculumMembership));
-    programmeMembership.setConditionsOfJoining(conditionsOfJoiningDto);
-
-    HeeUserDto roDto = new HeeUserDto();
-    roDto.setFirstName(RO_FIRST_NAME);
-    roDto.setLastName(RO_LAST_NAME);
-    roDto.setEmailAddress(RO_EMAIL);
-    roDto.setGmcId(RO_GMC);
-    roDto.setPhoneNumber(RO_PHONE);
-    programmeMembership.setResponsibleOfficer(roDto);
-
-    assertThrows(RuntimeException.class, () -> mapperSpy.toRecord(programmeMembership));
   }
 }


### PR DESCRIPTION
Reverts Health-Education-England/tis-trainee-sync#504

I'm going to accept that a written-as-string null object will be "null", and rather fix the action service to understand this, than make changes to a range of other services to modify their handling. Sorry @EdwardBarclay  - live and learn 😂 