### PR TITLE
refactor: message convert configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.21.0"
+version = "1.21.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/TisTraineeSyncApplication.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/TisTraineeSyncApplication.java
@@ -25,11 +25,7 @@ import io.mongock.runner.springboot.EnableMongock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
 
 @EnableCaching
 @EnableMongock
@@ -40,10 +36,4 @@ public class TisTraineeSyncApplication {
   public static void main(String[] args) {
     SpringApplication.run(TisTraineeSyncApplication.class, args);
   }
-
-  @Bean
-  RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.requestFactory(HttpComponentsClientHttpRequestFactory.class).build();
-  }
-
 }

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/config/ApplicationConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,25 +21,29 @@
 
 package uk.nhs.hee.tis.trainee.sync.config;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
-/**
- * General application configuration beans which do not warrant their own configuration class.
- */
-@Configuration
-public class ApplicationConfiguration {
+class ApplicationConfigurationTest {
 
-  /**
-   * Create a {@link RestTemplate} bean.
-   *
-   * @param builder The builder for the rest template.
-   * @return The built rest template.
-   */
-  @Bean
-  RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+  private ApplicationConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new ApplicationConfiguration();
+  }
+
+  @Test
+  void restTemplate() {
+    RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder();
+
+    RestTemplate restTemplate = configuration.restTemplate(restTemplateBuilder);
+
+    assertThat("Unexpected rest template.", restTemplate, notNullValue());
   }
 }


### PR DESCRIPTION
The MessageConverter no longer needs to be manually created to include the ObjectMapper, as the SQS starter now handles it automatically. The current MessageConverter is now conflicting with the auto-configuration so should be removed.

Move the RestTemplate config from the main application class to the ApplicationConfiguration class.

NO-TICKET