### PR TITLE
feat: remove College sync API calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.trainee"
-version = "1.24.1"
+version = "1.25.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
+++ b/src/main/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncService.java
@@ -45,8 +45,10 @@ public class ReferenceSyncService implements SyncService {
   private static final String API_TEMPLATE = "/api/{referenceType}";
   private static final String API_ID_TEMPLATE = "/api/{referenceType}/{tisId}";
 
+  // The reference service now handles some reference types itself.
+  private static final String MIGRATED = "MIGRATED";
   private static final Map<String, String> TABLE_NAME_TO_REFERENCE_TYPE = Map.of(
-      "College", "college",
+      "College", MIGRATED,
       "Curriculum", "curriculum",
       "DBC", "dbc",
       "Gender", "gender",
@@ -118,6 +120,9 @@ public class ReferenceSyncService implements SyncService {
 
     if (referenceType == null) {
       log.warn("Unhandled record table '{}'.", table);
+    } else if (referenceType.equals(MIGRATED)) {
+      log.debug("Skipped migrated record table '{}'.", table);
+      return Optional.empty();
     }
 
     return Optional.ofNullable(referenceType);

--- a/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/trainee/sync/service/ReferenceSyncServiceTest.java
@@ -83,7 +83,7 @@ class ReferenceSyncServiceTest {
   }
 
   @ParameterizedTest(name = "Should insert record when operation is LOAD and table is {0}")
-  @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
+  @CsvSource({"Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office",
       "LocalOfficeContact,local-office-contact", "LocalOfficeContactType,local-office-contact-type",
       "ProgrammeMembershipType,programme-membership-type"})
@@ -120,8 +120,32 @@ class ReferenceSyncServiceTest {
     verifyNoMoreInteractions(restTemplate);
   }
 
+  @ParameterizedTest(name = "Should not insert record when operation is LOAD and table is {0}")
+  @CsvSource({"College,college"})
+  void shouldNotInsertRecordWhenOperationIsLoadAndTypeWasMigrated(String tableName,
+      String apiName) {
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.LOAD);
+
+    Map<String, String> data = Map.of(
+        "abbreviation", "abbreviationValue",
+        "label", "labelValue",
+        "status", "CURRENT",
+        "uuid", "uuidValue",
+        "code", "codeValue",
+        "localOfficeId", "localOfficeIdValue",
+        "contactTypeId", "contactTypeIdValue",
+        "contact", "contactValue",
+        "id", "idValue");
+    recrd.setData(data);
+
+    service.syncRecord(recrd);
+
+    verifyNoInteractions(restTemplate);
+  }
+
   @ParameterizedTest(name = "Should insert record when operation is INSERT and table is {0}")
-  @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
+  @CsvSource({"Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office",
       "LocalOfficeContact,local-office-contact", "LocalOfficeContactType,local-office-contact-type",
       "ProgrammeMembershipType,programme-membership-type"})
@@ -158,8 +182,32 @@ class ReferenceSyncServiceTest {
     verifyNoMoreInteractions(restTemplate);
   }
 
+  @ParameterizedTest(name = "Should not insert record when operation is INSERT and table is {0}")
+  @CsvSource({"College,college"})
+  void shouldNotInsertRecordWhenOperationIsInsertAndTypeWasMigrated(String tableName,
+      String apiName) {
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.INSERT);
+
+    Map<String, String> data = Map.of(
+        "abbreviation", "abbreviationValue",
+        "label", "labelValue",
+        "status", "CURRENT",
+        "uuid", "uuidValue",
+        "code", "codeValue",
+        "localOfficeId", "localOfficeIdValue",
+        "contactTypeId", "contactTypeIdValue",
+        "contact", "contactValue",
+        "id", "idValue");
+    recrd.setData(data);
+
+    service.syncRecord(recrd);
+
+    verifyNoInteractions(restTemplate);
+  }
+
   @ParameterizedTest(name = "Should update record when operation is UPDATE and table is {0}")
-  @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
+  @CsvSource({"Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office",
       "LocalOfficeContact,local-office-contact", "LocalOfficeContactType,local-office-contact-type",
       "ProgrammeMembershipType,programme-membership-type"})
@@ -196,8 +244,32 @@ class ReferenceSyncServiceTest {
     verifyNoMoreInteractions(restTemplate);
   }
 
+  @ParameterizedTest(name = "Should not update record when operation is UPDATE and table is {0}")
+  @CsvSource({"College,college"})
+  void shouldNotUpdateRecordWhenOperationIsUpdateAndTypeWasMigrated(String tableName,
+      String apiName) {
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.UPDATE);
+
+    Map<String, String> data = Map.of(
+        "abbreviation", "abbreviationValue",
+        "label", "labelValue",
+        "status", "CURRENT",
+        "uuid", "uuidValue",
+        "code", "codeValue",
+        "localOfficeId", "localOfficeIdValue",
+        "contactTypeId", "contactTypeIdValue",
+        "contact", "contactValue",
+        "id", "idValue");
+    recrd.setData(data);
+
+    service.syncRecord(recrd);
+
+    verifyNoInteractions(restTemplate);
+  }
+
   @ParameterizedTest(name = "Should delete record when operation is DELETE and table is {0}")
-  @CsvSource({"College,college", "Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
+  @CsvSource({"Curriculum,curriculum", "DBC,dbc", "Gender,gender", "Grade,grade",
       "PermitToWork,immigration-status", "LocalOffice,local-office",
       "LocalOfficeContact,local-office-contact", "LocalOfficeContactType,local-office-contact-type",
       "ProgrammeMembershipType,programme-membership-type"})
@@ -211,6 +283,20 @@ class ReferenceSyncServiceTest {
 
     verify(restTemplate).delete(anyString(), eq(apiName), eq("40"));
     verifyNoMoreInteractions(restTemplate);
+  }
+
+  @ParameterizedTest(name = "Should not delete record when operation is DELETE and table is {0}")
+  @CsvSource({"College,college"})
+  void shouldNotDeleteRecordWhenOperationIsDeleteAndTypeWasMigrated(String tableName,
+      String apiName) {
+    recrd.setTisId("40");
+    recrd.setData(Collections.singletonMap("id", "40"));
+    recrd.setTable(tableName);
+    recrd.setOperation(Operation.DELETE);
+
+    service.syncRecord(recrd);
+
+    verifyNoInteractions(restTemplate);
   }
 
   @ParameterizedTest(name = "Should delete record when operation is {0} and status is INACTIVE")


### PR DESCRIPTION
The reference service is replacing its API endpoints for College updates with direct event handling from CDC.

Update the ReferenceSyncService to disable any handling of the College record type.
Other reference types will follow, until the ReferenceSyncService can be removed completely.

TIS21-7744
TIS21-8359